### PR TITLE
[Hana] Chapter 5. 프로젝트 세팅하기 - API 응답 통일, 에러 핸들러

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Gradle
+.gradle/
+build/
+!gradle/wrapper/gradle-wrapper.jar
+
+# IntelliJ
+.idea/
+*.iml
+out/
+
+# OS
+.DS_Store
+
+# Logs
+*.log
+
+# Application config
+application.yml
+application.properties

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testAnnotationProcessor 'org.projectlombok:lombok'
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:3.0.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/umc10th/domain/mission/enums/MissionStatus.java
+++ b/src/main/java/com/example/umc10th/domain/mission/enums/MissionStatus.java
@@ -1,2 +1,7 @@
-package com.example.umc10th.domain.mission.enums;public enum MissionStatus {
+package com.example.umc10th.domain.mission.enums;
+
+public enum MissionStatus {
+    ONGOING,
+    SUCCESS,
+    FAILED
 }

--- a/src/main/java/com/example/umc10th/domain/mission/enums/MissionStatus.java
+++ b/src/main/java/com/example/umc10th/domain/mission/enums/MissionStatus.java
@@ -1,0 +1,2 @@
+package com.example.umc10th.domain.mission.enums;public enum MissionStatus {
+}

--- a/src/main/java/com/example/umc10th/domain/mission/exception/MissionException.java
+++ b/src/main/java/com/example/umc10th/domain/mission/exception/MissionException.java
@@ -1,0 +1,10 @@
+package com.example.umc10th.domain.mission.exception;
+
+import com.example.umc10th.global.apiPayload.code.BaseErrorCode;
+import com.example.umc10th.global.apiPayload.exception.ProjectException;
+
+public class MissionException extends ProjectException {
+    public MissionException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/umc10th/domain/mission/exception/code/MissionErrorCode.java
+++ b/src/main/java/com/example/umc10th/domain/mission/exception/code/MissionErrorCode.java
@@ -1,0 +1,18 @@
+package com.example.umc10th.domain.mission.exception.code;
+
+import com.example.umc10th.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MissionErrorCode implements BaseErrorCode {
+
+    MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "MISSION404_1", "존재하지 않는 미션입니다."),
+    MISSION_ALREADY_CHALLENGED(HttpStatus.CONFLICT, "MISSION409_1", "이미 도전 중인 미션입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/umc10th/domain/mission/exception/code/MissionSuccessCode.java
+++ b/src/main/java/com/example/umc10th/domain/mission/exception/code/MissionSuccessCode.java
@@ -1,0 +1,4 @@
+package com.example.umc10th.domain.mission.exception.code;
+
+public enum MissionSuccessCode {
+}

--- a/src/main/java/com/example/umc10th/domain/restaurant/exception/RestaurantException.java
+++ b/src/main/java/com/example/umc10th/domain/restaurant/exception/RestaurantException.java
@@ -1,0 +1,10 @@
+package com.example.umc10th.domain.restaurant.exception;
+
+import com.example.umc10th.global.apiPayload.code.BaseErrorCode;
+import com.example.umc10th.global.apiPayload.exception.ProjectException;
+
+public class RestaurantException extends ProjectException {
+    public RestaurantException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/umc10th/domain/restaurant/exception/code/RestaurantErrorCode.java
+++ b/src/main/java/com/example/umc10th/domain/restaurant/exception/code/RestaurantErrorCode.java
@@ -1,0 +1,17 @@
+package com.example.umc10th.domain.restaurant.exception.code;
+
+import com.example.umc10th.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RestaurantErrorCode implements BaseErrorCode {
+
+    RESTAURANT_NOT_FOUND(HttpStatus.NOT_FOUND, "RESTAURANT404_1", "존재하지 않는 가게입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/umc10th/domain/restaurant/exception/code/RestaurantSuccessCode.java
+++ b/src/main/java/com/example/umc10th/domain/restaurant/exception/code/RestaurantSuccessCode.java
@@ -1,0 +1,4 @@
+package com.example.umc10th.domain.restaurant.exception.code;
+
+public enum RestaurantSuccessCode {
+}

--- a/src/main/java/com/example/umc10th/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/umc10th/domain/review/controller/ReviewController.java
@@ -1,6 +1,5 @@
 package com.example.umc10th.domain.review.controller;
 
-
 import com.example.umc10th.domain.review.exception.code.ReviewSuccessCode;
 import com.example.umc10th.domain.review.dto.ReviewReqDTO;
 import com.example.umc10th.domain.review.dto.ReviewResDTO;

--- a/src/main/java/com/example/umc10th/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/umc10th/domain/review/controller/ReviewController.java
@@ -1,0 +1,24 @@
+package com.example.umc10th.domain.review.controller;
+
+
+import com.example.umc10th.domain.review.exception.code.ReviewSuccessCode;
+import com.example.umc10th.domain.review.dto.ReviewReqDTO;
+import com.example.umc10th.domain.review.dto.ReviewResDTO;
+import com.example.umc10th.global.apiPayload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/stores")
+public class ReviewController {
+
+    // 리뷰 작성
+    @PostMapping("/{storeId}/reviews")
+    public ApiResponse<ReviewResDTO.CreateReviewRes> createReview(
+            @PathVariable Long storeId,
+            @RequestBody ReviewReqDTO.CreateReviewReq request
+    ) {
+        return ApiResponse.onSuccess(ReviewSuccessCode.REVIEW_CREATE_OK, null);
+    }
+}

--- a/src/main/java/com/example/umc10th/domain/review/dto/ReviewReqDTO.java
+++ b/src/main/java/com/example/umc10th/domain/review/dto/ReviewReqDTO.java
@@ -1,0 +1,15 @@
+package com.example.umc10th.domain.review.dto;
+
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+import java.util.List;
+
+public class ReviewReqDTO {
+
+    @Getter
+    public static class CreateReviewReq {
+        private Integer rating;
+        private String content;
+        private List<MultipartFile> images; // 선택
+    }
+}

--- a/src/main/java/com/example/umc10th/domain/review/dto/ReviewResDTO.java
+++ b/src/main/java/com/example/umc10th/domain/review/dto/ReviewResDTO.java
@@ -1,0 +1,16 @@
+package com.example.umc10th.domain.review.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class ReviewResDTO {
+
+    @Getter
+    @AllArgsConstructor
+    public static class CreateReviewRes {
+        private Long reviewId;
+        private Long storeId;
+        private Integer rating;
+        private String content;
+    }
+}

--- a/src/main/java/com/example/umc10th/domain/review/exception/ReviewException.java
+++ b/src/main/java/com/example/umc10th/domain/review/exception/ReviewException.java
@@ -1,0 +1,10 @@
+package com.example.umc10th.domain.review.exception;
+
+import com.example.umc10th.global.apiPayload.code.BaseErrorCode;
+import com.example.umc10th.global.apiPayload.exception.ProjectException;
+
+public class ReviewException extends ProjectException {
+    public ReviewException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/umc10th/domain/review/exception/code/ReviewErrorCode.java
+++ b/src/main/java/com/example/umc10th/domain/review/exception/code/ReviewErrorCode.java
@@ -1,0 +1,17 @@
+package com.example.umc10th.domain.review.exception.code;
+
+import com.example.umc10th.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReviewErrorCode implements BaseErrorCode {
+
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_1", "존재하지 않는 리뷰입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/umc10th/domain/review/exception/code/ReviewSuccessCode.java
+++ b/src/main/java/com/example/umc10th/domain/review/exception/code/ReviewSuccessCode.java
@@ -1,0 +1,4 @@
+package com.example.umc10th.domain.review.exception.code;
+
+public enum ReviewSuccessCode {
+}

--- a/src/main/java/com/example/umc10th/domain/review/exception/code/ReviewSuccessCode.java
+++ b/src/main/java/com/example/umc10th/domain/review/exception/code/ReviewSuccessCode.java
@@ -1,4 +1,17 @@
 package com.example.umc10th.domain.review.exception.code;
 
-public enum ReviewSuccessCode {
+import com.example.umc10th.global.apiPayload.code.BaseSuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReviewSuccessCode implements BaseSuccessCode {
+
+    REVIEW_CREATE_OK(HttpStatus.CREATED, "REVIEW_2000", "리뷰 작성 성공");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
 }

--- a/src/main/java/com/example/umc10th/domain/review/exception/code/ReviewSuccessCode.java
+++ b/src/main/java/com/example/umc10th/domain/review/exception/code/ReviewSuccessCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ReviewSuccessCode implements BaseSuccessCode {
 
-    REVIEW_CREATE_OK(HttpStatus.CREATED, "REVIEW_2000", "리뷰 작성 성공");
+    REVIEW_CREATE_OK(HttpStatus.CREATED, "REVIEW_201", "리뷰 작성 성공");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/umc10th/domain/user/controller/AuthController.java
+++ b/src/main/java/com/example/umc10th/domain/user/controller/AuthController.java
@@ -1,2 +1,22 @@
-package com.example.umc10th.domain.user.controller;public class AuthController {
+package com.example.umc10th.domain.user.controller;
+
+import com.example.umc10th.domain.user.dto.UserReqDTO;
+import com.example.umc10th.domain.user.dto.UserResDTO;
+import com.example.umc10th.global.apiPayload.ApiResponse;
+import com.example.umc10th.global.apiPayload.code.GeneralSuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    // 회원가입
+    @PostMapping("/users")
+    public ApiResponse<UserResDTO.JoinRes> join(
+            @RequestBody UserReqDTO.JoinReq request
+    ) {
+        return ApiResponse.onSuccess(GeneralSuccessCode.USER_JOIN_OK, null);
+    }
 }

--- a/src/main/java/com/example/umc10th/domain/user/controller/AuthController.java
+++ b/src/main/java/com/example/umc10th/domain/user/controller/AuthController.java
@@ -2,8 +2,8 @@ package com.example.umc10th.domain.user.controller;
 
 import com.example.umc10th.domain.user.dto.UserReqDTO;
 import com.example.umc10th.domain.user.dto.UserResDTO;
+import com.example.umc10th.domain.user.exception.code.UserSuccessCode;
 import com.example.umc10th.global.apiPayload.ApiResponse;
-import com.example.umc10th.global.apiPayload.code.GeneralSuccessCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,6 +17,6 @@ public class AuthController {
     public ApiResponse<UserResDTO.JoinRes> join(
             @RequestBody UserReqDTO.JoinReq request
     ) {
-        return ApiResponse.onSuccess(GeneralSuccessCode.USER_JOIN_OK, null);
+        return ApiResponse.onSuccess(UserSuccessCode.USER_JOIN_OK, null);
     }
 }

--- a/src/main/java/com/example/umc10th/domain/user/controller/AuthController.java
+++ b/src/main/java/com/example/umc10th/domain/user/controller/AuthController.java
@@ -1,0 +1,2 @@
+package com.example.umc10th.domain.user.controller;public class AuthController {
+}

--- a/src/main/java/com/example/umc10th/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/umc10th/domain/user/controller/UserController.java
@@ -3,9 +3,8 @@ package com.example.umc10th.domain.user.controller;
 import com.example.umc10th.domain.mission.enums.MissionStatus;
 import com.example.umc10th.domain.user.dto.UserReqDTO;
 import com.example.umc10th.domain.user.dto.UserResDTO;
-import com.example.umc10th.domain.user.dto.UserResDTO;
+import com.example.umc10th.domain.user.exception.code.UserSuccessCode;
 import com.example.umc10th.global.apiPayload.ApiResponse;
-import com.example.umc10th.global.apiPayload.code.GeneralSuccessCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
@@ -18,13 +17,13 @@ public class UserController {
     // 사용자 정보 및 포인트 조회
     @GetMapping
     public ApiResponse<UserResDTO.UserInfoRes> getUserInfo() {
-        return ApiResponse.onSuccess(GeneralSuccessCode.USER_INFO_OK, null);
+        return ApiResponse.onSuccess(UserSuccessCode.USER_INFO_OK, null);
     }
 
     // 미션 진행 현황 조회
     @GetMapping("/mission-progress")
     public ApiResponse<UserResDTO.MissionProgressRes> getMissionProgress() {
-        return ApiResponse.onSuccess(GeneralSuccessCode.USER_MISSION_PROGRESS_OK, null);
+        return ApiResponse.onSuccess(UserSuccessCode.USER_MISSION_PROGRESS_OK, null);
     }
 
     // 내가 받은 미션 목록 조회 + 미션 목록 조회 (status 필터)
@@ -32,7 +31,7 @@ public class UserController {
     public ApiResponse<List<UserResDTO.MissionRes>> getMyMissions(
             @RequestParam(required = false) MissionStatus status
     ) {
-        return ApiResponse.onSuccess(GeneralSuccessCode.USER_MISSIONS_OK, null);
+        return ApiResponse.onSuccess(UserSuccessCode.USER_MISSIONS_OK, null);
     }
 
     // 미션 도전하기
@@ -40,7 +39,7 @@ public class UserController {
     public ApiResponse<UserResDTO.MissionChallengeRes> challengeMission(
             @PathVariable Long missionId
     ) {
-        return ApiResponse.onSuccess(GeneralSuccessCode.USER_MISSION_CHALLENGE_OK, null);
+        return ApiResponse.onSuccess(UserSuccessCode.USER_MISSION_CHALLENGE_OK, null);
     }
 
     // 미션 성공 누르기
@@ -49,6 +48,6 @@ public class UserController {
             @PathVariable Long userMissionId,
             @RequestBody UserReqDTO.MissionSuccessReq request
     ) {
-        return ApiResponse.onSuccess(GeneralSuccessCode.USER_MISSION_SUCCESS_OK, null);
+        return ApiResponse.onSuccess(UserSuccessCode.USER_MISSION_SUCCESS_OK, null);
     }
 }

--- a/src/main/java/com/example/umc10th/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/umc10th/domain/user/controller/UserController.java
@@ -1,0 +1,54 @@
+package com.example.umc10th.domain.user.controller;
+
+import com.example.umc10th.domain.mission.enums.MissionStatus;
+import com.example.umc10th.domain.user.dto.UserReqDTO;
+import com.example.umc10th.domain.user.dto.UserResDTO;
+import com.example.umc10th.domain.user.dto.UserResDTO;
+import com.example.umc10th.global.apiPayload.ApiResponse;
+import com.example.umc10th.global.apiPayload.code.GeneralSuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users/me")
+public class UserController {
+
+    // 사용자 정보 및 포인트 조회
+    @GetMapping
+    public ApiResponse<UserResDTO.UserInfoRes> getUserInfo() {
+        return ApiResponse.onSuccess(GeneralSuccessCode.USER_INFO_OK, null);
+    }
+
+    // 미션 진행 현황 조회
+    @GetMapping("/mission-progress")
+    public ApiResponse<UserResDTO.MissionProgressRes> getMissionProgress() {
+        return ApiResponse.onSuccess(GeneralSuccessCode.USER_MISSION_PROGRESS_OK, null);
+    }
+
+    // 내가 받은 미션 목록 조회 + 미션 목록 조회 (status 필터)
+    @GetMapping("/missions")
+    public ApiResponse<List<UserResDTO.MissionRes>> getMyMissions(
+            @RequestParam(required = false) MissionStatus status
+    ) {
+        return ApiResponse.onSuccess(GeneralSuccessCode.USER_MISSIONS_OK, null);
+    }
+
+    // 미션 도전하기
+    @PostMapping("/missions/{missionId}/challenge")
+    public ApiResponse<UserResDTO.MissionChallengeRes> challengeMission(
+            @PathVariable Long missionId
+    ) {
+        return ApiResponse.onSuccess(GeneralSuccessCode.USER_MISSION_CHALLENGE_OK, null);
+    }
+
+    // 미션 성공 누르기
+    @PatchMapping("/missions/{userMissionId}")
+    public ApiResponse<UserResDTO.MissionChallengeRes> successMission(
+            @PathVariable Long userMissionId,
+            @RequestBody UserReqDTO.MissionSuccessReq request
+    ) {
+        return ApiResponse.onSuccess(GeneralSuccessCode.USER_MISSION_SUCCESS_OK, null);
+    }
+}

--- a/src/main/java/com/example/umc10th/domain/user/dto/UserReqDTO.java
+++ b/src/main/java/com/example/umc10th/domain/user/dto/UserReqDTO.java
@@ -1,0 +1,25 @@
+package com.example.umc10th.domain.user.dto;
+
+import com.example.umc10th.domain.mission.enums.MissionStatus;
+import lombok.Getter;
+import java.time.LocalDate;
+
+public class UserReqDTO {
+
+    @Getter
+    public static class JoinReq {
+        private String name;
+        private String gender;
+        private String email;
+        private String password;
+        private String nickname;
+        private String address;
+        private LocalDate birth;
+        private String phone; // 선택
+    }
+
+    @Getter
+    public static class MissionSuccessReq {
+        private MissionStatus status;
+    }
+}

--- a/src/main/java/com/example/umc10th/domain/user/dto/UserResDTO.java
+++ b/src/main/java/com/example/umc10th/domain/user/dto/UserResDTO.java
@@ -1,0 +1,50 @@
+package com.example.umc10th.domain.user.dto;
+
+import com.example.umc10th.domain.mission.enums.MissionStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import java.util.List;
+
+public class UserResDTO {
+
+    @Getter
+    @AllArgsConstructor
+    public static class UserInfoRes {
+        private Long userId;
+        private String name;
+        private String nickname;
+        private Integer point;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class MissionProgressRes {
+        private Integer totalMissions;
+        private Integer successMissions;
+        private Integer ongoingMissions;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class MissionRes {
+        private Long missionId;
+        private String title;
+        private Integer point;
+        private MissionStatus status;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class MissionChallengeRes {
+        private Long userMissionId;
+        private MissionStatus status;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class JoinRes {
+        private Long userId;
+        private String name;
+        private String email;
+    }
+}

--- a/src/main/java/com/example/umc10th/domain/user/exception/UserException.java
+++ b/src/main/java/com/example/umc10th/domain/user/exception/UserException.java
@@ -1,0 +1,10 @@
+package com.example.umc10th.domain.user.exception;
+
+import com.example.umc10th.global.apiPayload.code.BaseErrorCode;
+import com.example.umc10th.global.apiPayload.exception.ProjectException;
+
+public class UserException extends ProjectException {
+    public UserException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/umc10th/domain/user/exception/code/UserErrorCode.java
+++ b/src/main/java/com/example/umc10th/domain/user/exception/code/UserErrorCode.java
@@ -1,0 +1,18 @@
+package com.example.umc10th.domain.user.exception.code;
+
+import com.example.umc10th.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements BaseErrorCode {
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404_1", "존재하지 않는 사용자입니다."),
+    USER_EMAIL_DUPLICATE(HttpStatus.CONFLICT, "USER409_1", "이미 사용중인 이메일입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/umc10th/domain/user/exception/code/UserSuccessCode.java
+++ b/src/main/java/com/example/umc10th/domain/user/exception/code/UserSuccessCode.java
@@ -1,0 +1,4 @@
+package com.example.umc10th.domain.user.exception.code;
+
+public enum UserSuccessCode {
+}

--- a/src/main/java/com/example/umc10th/domain/user/exception/code/UserSuccessCode.java
+++ b/src/main/java/com/example/umc10th/domain/user/exception/code/UserSuccessCode.java
@@ -1,4 +1,22 @@
 package com.example.umc10th.domain.user.exception.code;
 
-public enum UserSuccessCode {
+import com.example.umc10th.global.apiPayload.code.BaseSuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserSuccessCode implements BaseSuccessCode {
+
+    USER_INFO_OK(HttpStatus.OK, "USER_2000", "사용자 정보 조회 성공"),
+    USER_MISSION_PROGRESS_OK(HttpStatus.OK, "USER_2001", "미션 진행 현황 조회 성공"),
+    USER_MISSIONS_OK(HttpStatus.OK, "USER_2002", "미션 목록 조회 성공"),
+    USER_MISSION_CHALLENGE_OK(HttpStatus.CREATED, "USER_2003", "미션 도전 성공"),
+    USER_MISSION_SUCCESS_OK(HttpStatus.OK, "USER_2004", "미션 성공 처리 완료"),
+    USER_JOIN_OK(HttpStatus.CREATED, "USER_2005", "회원가입 성공");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
 }

--- a/src/main/java/com/example/umc10th/domain/user/exception/code/UserSuccessCode.java
+++ b/src/main/java/com/example/umc10th/domain/user/exception/code/UserSuccessCode.java
@@ -9,12 +9,12 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserSuccessCode implements BaseSuccessCode {
 
-    USER_INFO_OK(HttpStatus.OK, "USER_2000", "사용자 정보 조회 성공"),
-    USER_MISSION_PROGRESS_OK(HttpStatus.OK, "USER_2001", "미션 진행 현황 조회 성공"),
-    USER_MISSIONS_OK(HttpStatus.OK, "USER_2002", "미션 목록 조회 성공"),
-    USER_MISSION_CHALLENGE_OK(HttpStatus.CREATED, "USER_2003", "미션 도전 성공"),
-    USER_MISSION_SUCCESS_OK(HttpStatus.OK, "USER_2004", "미션 성공 처리 완료"),
-    USER_JOIN_OK(HttpStatus.CREATED, "USER_2005", "회원가입 성공");
+    USER_INFO_OK(HttpStatus.OK, "200_0", "사용자 정보 조회 성공"),
+    USER_MISSION_PROGRESS_OK(HttpStatus.OK, "200_1", "미션 진행 현황 조회 성공"),
+    USER_MISSIONS_OK(HttpStatus.OK, "200_2", "미션 목록 조회 성공"),
+    USER_MISSION_CHALLENGE_CREATED(HttpStatus.CREATED, "200_3", "미션 도전 성공"),
+    USER_MISSION_SUCCESS_OK(HttpStatus.OK, "200_4", "미션 성공 처리 완료"),
+    USER_JOIN_CREATED(HttpStatus.CREATED, "201_0", "회원가입 성공");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/umc10th/global/apiPayload/ApiResponse.java
+++ b/src/main/java/com/example/umc10th/global/apiPayload/ApiResponse.java
@@ -1,0 +1,39 @@
+package com.example.umc10th.global.apiPayload;
+
+import com.example.umc10th.global.apiPayload.code.BaseErrorCode;
+import com.example.umc10th.global.apiPayload.code.BaseSuccessCode;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+import lombok.AllArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+
+    @JsonProperty("code")
+    private final String code;
+
+    @JsonProperty("message")
+    private final String message;
+
+    @JsonProperty("result")
+    private final T result;
+
+
+    public static <T> ApiResponse<T> onSuccess(BaseSuccessCode successCode, T result) {
+        return new ApiResponse<>(true, successCode.getCode(), successCode.getMessage(), result);
+    }
+
+    public static <T> ApiResponse<T> onFailure(BaseErrorCode errorCode, T result) {
+        return new ApiResponse<>(false, errorCode.getCode(), errorCode.getMessage(), result);
+    }
+
+    public static ApiResponse<Void> onFailure(BaseErrorCode code) {
+        return onFailure(code, null);
+    }
+}

--- a/src/main/java/com/example/umc10th/global/apiPayload/ApiResponse.java
+++ b/src/main/java/com/example/umc10th/global/apiPayload/ApiResponse.java
@@ -29,6 +29,10 @@ public class ApiResponse<T> {
         return new ApiResponse<>(true, successCode.getCode(), successCode.getMessage(), result);
     }
 
+    public static ApiResponse<Void> onSuccess(BaseSuccessCode successCode) {
+        return onSuccess(successCode, null);
+    }
+
     public static <T> ApiResponse<T> onFailure(BaseErrorCode errorCode, T result) {
         return new ApiResponse<>(false, errorCode.getCode(), errorCode.getMessage(), result);
     }

--- a/src/main/java/com/example/umc10th/global/apiPayload/code/BaseErrorCode.java
+++ b/src/main/java/com/example/umc10th/global/apiPayload/code/BaseErrorCode.java
@@ -1,0 +1,9 @@
+package com.example.umc10th.global.apiPayload.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCode {
+    HttpStatus getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/com/example/umc10th/global/apiPayload/code/BaseSuccessCode.java
+++ b/src/main/java/com/example/umc10th/global/apiPayload/code/BaseSuccessCode.java
@@ -1,0 +1,9 @@
+package com.example.umc10th.global.apiPayload.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseSuccessCode {
+    HttpStatus getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/com/example/umc10th/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/example/umc10th/global/apiPayload/code/GeneralErrorCode.java
@@ -1,0 +1,29 @@
+package com.example.umc10th.global.apiPayload.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GeneralErrorCode implements BaseErrorCode {
+    BAD_REQUEST(HttpStatus.BAD_REQUEST,
+            "COMMON400_1",
+            "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED,
+            "COMMON401_1",
+            "인증되지 않았습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN,
+            "COMMON403_1",
+            "접근이 금지되었습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND,
+            "COMMON404_1",
+            "해당 리소스를 찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,
+            "COMMON500_1",
+            "서버 에러가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/umc10th/global/apiPayload/code/GeneralSuccessCode.java
+++ b/src/main/java/com/example/umc10th/global/apiPayload/code/GeneralSuccessCode.java
@@ -1,0 +1,19 @@
+package com.example.umc10th.global.apiPayload.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GeneralSuccessCode implements BaseSuccessCode {
+
+    OK(HttpStatus.OK,
+            "COMMON200_1",
+            "성공적으로 요청을 처리했습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/umc10th/global/apiPayload/exception/ProjectException.java
+++ b/src/main/java/com/example/umc10th/global/apiPayload/exception/ProjectException.java
@@ -1,0 +1,11 @@
+package com.example.umc10th.global.apiPayload.exception;
+
+import com.example.umc10th.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ProjectException extends RuntimeException {
+    private final BaseErrorCode errorCode;
+}

--- a/src/main/java/com/example/umc10th/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/example/umc10th/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -1,0 +1,34 @@
+package com.example.umc10th.global.apiPayload.handler;
+
+import com.example.umc10th.global.apiPayload.ApiResponse;
+import com.example.umc10th.global.apiPayload.code.BaseErrorCode;
+import com.example.umc10th.global.apiPayload.code.GeneralErrorCode;
+import com.example.umc10th.global.apiPayload.exception.ProjectException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GeneralExceptionAdvice {
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleMemberException(
+            ProjectException e
+    ){
+        BaseErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.onFailure(errorCode, null));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<String>> handleException(
+            Exception ex
+    ) {
+        BaseErrorCode code = GeneralErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity.status(code.getStatus())
+                .body(ApiResponse.onFailure(
+                        code,
+                        ex.getMessage()
+                        )
+                );
+    }
+}

--- a/src/main/java/com/example/umc10th/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/umc10th/global/config/SwaggerConfig.java
@@ -1,0 +1,36 @@
+package com.example.umc10th.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI swagger() {
+        Info info = new Info().title("UMC10th").description("10기 Swagger").version("0.0.1");
+
+        // JWT 토큰 헤더 방식
+        String securityScheme = "JWT TOKEN";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(securityScheme);
+
+        Components components = new Components()
+                .addSecuritySchemes(securityScheme, new SecurityScheme()
+                        .name(securityScheme)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("Bearer")
+                        .bearerFormat("JWT"));
+
+        return new OpenAPI()
+                .info(info)
+                .addServersItem(new Server().url("/"))
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+}


### PR DESCRIPTION
## ✅ 워크북 체크리스트

- [x] 모든 핵심 키워드 정리를 마쳤나요?
- [x] 핵심 키워드에 대해 완벽히 이해하셨나요?
- [x] 이론 학습 이후 직접 실습을 해보는 시간을 가졌나요?
- [x] 미션을 수행하셨나요?
- [x] 미션을 기록하셨나요?
<br>

## ✅ 컨벤션 체크리스트

- [x] 디렉토리 구조 컨벤션을 잘 지켰나요?
- [x] pr 제목을 컨벤션에 맞게 작성하였나요?
- [x] pr에 해당되는 이슈를 연결하였나요?
- [x] 적절한 라벨을 설정하였나요?
- [x] 스터디원들에게 code review를 요청하기 위해 reviewer를 등록하였나요?
- [x] 닉네임/main 브랜치의 최신 상태를 반영하고 있는지 확인했나요?
<br>

## 📌 주안점
- 응답 통일 객체 설계
 ApiResponse<T>로 모든 응답을 isSuccess, code, message, result 형태로 통일
성공/실패 응답을 onSuccess, onFailure 메서드로 일관성 있게 처리

- 에러 핸들링 구조화
BaseErrorCode 인터페이스를 통해 도메인별 에러코드를 일관되게 관리
GlobalExceptionHandler로 예외를 한 곳에서 처리해 응답 형식을 통일
ProjectException을 상속받는 도메인별 Exception 클래스를 만들어 계층적으로 관리

- 휴먼 에러 방지
성공/에러 코드를 enum으로 관리해 오타나 중복 작성을 방지
MissionStatus를 enum으로 만들어 유효하지 않은 값이 들어오는 것을 방지

- 현재 상태
Service, Repository가 아직 구현되지 않아 Controller에서 null을 반환하고 있다. 이후 Service 구현 시 실제 비즈니스 로직으로 교체할 예정이다.

close #20 