### PR TITLE
[Hana] Chapter 7. API 설계 심화 - 페이징

### DIFF
--- a/src/main/java/com/example/umc10th/domain/food/entity/FoodCategory.java
+++ b/src/main/java/com/example/umc10th/domain/food/entity/FoodCategory.java
@@ -1,0 +1,21 @@
+package com.example.umc10th.domain.food.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "food_category")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class FoodCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "food_category_id")
+    private Long id;
+
+    @Column(name = "food_name", nullable = false, length = 20)
+    private String foodName;
+}

--- a/src/main/java/com/example/umc10th/domain/food/entity/UserFoodFavor.java
+++ b/src/main/java/com/example/umc10th/domain/food/entity/UserFoodFavor.java
@@ -1,0 +1,27 @@
+package com.example.umc10th.domain.food.entity;
+
+import com.example.umc10th.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "user_food_favor")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserFoodFavor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_food_favor_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "food_category_id", nullable = false)
+    private FoodCategory foodCategory;
+}

--- a/src/main/java/com/example/umc10th/domain/food/repository/FoodCategoryRepository.java
+++ b/src/main/java/com/example/umc10th/domain/food/repository/FoodCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.example.umc10th.domain.food.repository;
+
+import com.example.umc10th.domain.food.entity.FoodCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FoodCategoryRepository extends JpaRepository<FoodCategory, Long> {
+}

--- a/src/main/java/com/example/umc10th/domain/location/entity/Location.java
+++ b/src/main/java/com/example/umc10th/domain/location/entity/Location.java
@@ -1,0 +1,24 @@
+package com.example.umc10th.domain.location.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "location")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Location {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "location_id")
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+}

--- a/src/main/java/com/example/umc10th/domain/location/repository/LocationRepository.java
+++ b/src/main/java/com/example/umc10th/domain/location/repository/LocationRepository.java
@@ -1,0 +1,7 @@
+package com.example.umc10th.domain.location.repository;
+
+import com.example.umc10th.domain.location.entity.Location;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LocationRepository extends JpaRepository<Location, Long> {
+}

--- a/src/main/java/com/example/umc10th/domain/mission/controller/MissionController.java
+++ b/src/main/java/com/example/umc10th/domain/mission/controller/MissionController.java
@@ -1,0 +1,49 @@
+package com.example.umc10th.domain.mission.controller;
+
+import com.example.umc10th.domain.mission.dto.MissionResDTO;
+import com.example.umc10th.domain.mission.enums.MissionStatus;
+import com.example.umc10th.domain.mission.exception.code.MissionSuccessCode;
+import com.example.umc10th.domain.mission.service.MissionService;
+import com.example.umc10th.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "미션", description = "미션 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/missions")
+public class MissionController {
+
+    private final MissionService missionService;
+
+    @Operation(
+            summary = "내 미션 목록 조회 (페이징)",
+            description = "진행중(ONGOING) 또는 완료(SUCCESS) 상태의 내 미션 목록을 페이징으로 조회합니다."
+    )
+    @GetMapping("/my")
+    public ApiResponse<MissionResDTO.MyMissionListRes> getMyMissions(
+            @Parameter(description = "유저 ID") @RequestParam Long userId,
+            @Parameter(description = "미션 상태 (ONGOING / SUCCESS)") @RequestParam MissionStatus status,
+            @Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(defaultValue = "0") int page
+    ) {
+        MissionResDTO.MyMissionListRes result = missionService.getMyMissions(userId, status, page);
+        return ApiResponse.onSuccess(MissionSuccessCode.MY_MISSIONS_OK, result);
+    }
+
+    @Operation(
+            summary = "홈 화면 - 도전 가능한 미션 목록 (페이징)",
+            description = "현재 선택된 지역에서 아직 도전하지 않은 미션 목록을 페이징으로 조회합니다."
+    )
+    @GetMapping("/home")
+    public ApiResponse<MissionResDTO.HomeMissionListRes> getHomeMissions(
+            @Parameter(description = "유저 ID") @RequestParam Long userId,
+            @Parameter(description = "지역 ID") @RequestParam Long locationId,
+            @Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(defaultValue = "0") int page
+    ) {
+        MissionResDTO.HomeMissionListRes result = missionService.getHomeMissions(userId, locationId, page);
+        return ApiResponse.onSuccess(MissionSuccessCode.HOME_MISSIONS_OK, result);
+    }
+}

--- a/src/main/java/com/example/umc10th/domain/mission/converter/MissionConverter.java
+++ b/src/main/java/com/example/umc10th/domain/mission/converter/MissionConverter.java
@@ -1,0 +1,27 @@
+package com.example.umc10th.domain.mission.converter;
+
+import com.example.umc10th.domain.mission.dto.MemberMissionResDTO;
+import com.example.umc10th.domain.mission.dto.MissionResDTO;
+import com.example.umc10th.domain.mission.entity.mapping.UserMission;
+
+import java.util.List;
+
+public class MissionConverter {
+
+    public static MemberMissionResDTO.OngoingMissionItem toOngoingMissionItem(UserMission userMission) {
+        return MemberMissionResDTO.OngoingMissionItem.builder()
+                .missionId(userMission.getMission().getId())
+                .point(userMission.getMission().getRewardPoint())
+                .conditional(userMission.getMission().getDescription())
+                .deadline(null)
+                .build();
+    }
+
+    public static <T> MissionResDTO.OffsetPaginationRes<T> toPagination(List<T> data, Integer pageNumber, Integer pageSize) {
+        return MissionResDTO.OffsetPaginationRes.<T>builder()
+                .data(data)
+                .pageNumber(pageNumber)
+                .pageSize(pageSize)
+                .build();
+    }
+}

--- a/src/main/java/com/example/umc10th/domain/mission/dto/MemberMissionResDTO.java
+++ b/src/main/java/com/example/umc10th/domain/mission/dto/MemberMissionResDTO.java
@@ -1,0 +1,20 @@
+package com.example.umc10th.domain.mission.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+public class MemberMissionResDTO {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class OngoingMissionItem {
+        private Long missionId;
+        private Integer point;
+        private String conditional;
+        private LocalDate deadline;
+    }
+}

--- a/src/main/java/com/example/umc10th/domain/mission/dto/MissionReqDTO.java
+++ b/src/main/java/com/example/umc10th/domain/mission/dto/MissionReqDTO.java
@@ -1,0 +1,5 @@
+package com.example.umc10th.domain.mission.dto;
+
+public class MissionReqDTO {
+    // 현재 요청 DTO는 Controller 파라미터(@RequestParam, @PathVariable)로 처리
+}

--- a/src/main/java/com/example/umc10th/domain/mission/dto/MissionResDTO.java
+++ b/src/main/java/com/example/umc10th/domain/mission/dto/MissionResDTO.java
@@ -45,4 +45,13 @@ public class MissionResDTO {
         private List<HomeMissionItem> missions;
         private boolean hasNext;
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class OffsetPaginationRes<T> {
+        private List<T> data;
+        private Integer pageNumber;
+        private Integer pageSize;
+    }
 }

--- a/src/main/java/com/example/umc10th/domain/mission/dto/MissionResDTO.java
+++ b/src/main/java/com/example/umc10th/domain/mission/dto/MissionResDTO.java
@@ -1,0 +1,48 @@
+package com.example.umc10th.domain.mission.dto;
+
+import com.example.umc10th.domain.mission.enums.MissionStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+public class MissionResDTO {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class MyMissionItem {
+        private String restaurantName;
+        private Integer rewardPoint;
+        private MissionStatus status;
+        private String description;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class MyMissionListRes {
+        private List<MyMissionItem> missions;
+        private boolean hasNext;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class HomeMissionItem {
+        private String restaurantName;
+        private String description;
+        private Integer rewardPoint;
+        private Long successCount;
+        private Long totalCount;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class HomeMissionListRes {
+        private List<HomeMissionItem> missions;
+        private boolean hasNext;
+    }
+}

--- a/src/main/java/com/example/umc10th/domain/mission/entity/Mission.java
+++ b/src/main/java/com/example/umc10th/domain/mission/entity/Mission.java
@@ -1,0 +1,32 @@
+package com.example.umc10th.domain.mission.entity;
+
+import com.example.umc10th.domain.restaurant.entity.Restaurant;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "mission")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Mission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mission_id")
+    private Long id;
+
+    @Column(length = 50)
+    private String title;
+
+    @Column(length = 100)
+    private String description;
+
+    @Column(name = "reward_point")
+    private Integer rewardPoint;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "restaurant_id", nullable = false)
+    private Restaurant restaurant;
+}

--- a/src/main/java/com/example/umc10th/domain/mission/entity/mapping/UserMission.java
+++ b/src/main/java/com/example/umc10th/domain/mission/entity/mapping/UserMission.java
@@ -1,0 +1,37 @@
+package com.example.umc10th.domain.mission.entity.mapping;
+
+import com.example.umc10th.domain.mission.entity.Mission;
+import com.example.umc10th.domain.mission.enums.MissionStatus;
+import com.example.umc10th.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "user_mission")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserMission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_mission_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private MissionStatus status = MissionStatus.ONGOING;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id", nullable = false)
+    private Mission mission;
+
+    public void updateStatus(MissionStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/example/umc10th/domain/mission/exception/code/MissionSuccessCode.java
+++ b/src/main/java/com/example/umc10th/domain/mission/exception/code/MissionSuccessCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum MissionSuccessCode implements BaseSuccessCode {
 
     MY_MISSIONS_OK(HttpStatus.OK, "MISSION_200_0", "내 미션 목록 조회 성공"),
-    HOME_MISSIONS_OK(HttpStatus.OK, "MISSION_200_1", "홈 미션 목록 조회 성공");
+    HOME_MISSIONS_OK(HttpStatus.OK, "MISSION_200_1", "홈 미션 목록 조회 성공"),
+    ONGOING_MISSIONS_OK(HttpStatus.OK, "MISSION_200_2", "진행중인 미션 목록 조회 성공");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/umc10th/domain/mission/exception/code/MissionSuccessCode.java
+++ b/src/main/java/com/example/umc10th/domain/mission/exception/code/MissionSuccessCode.java
@@ -1,4 +1,19 @@
 package com.example.umc10th.domain.mission.exception.code;
 
-public enum MissionSuccessCode {
+import com.example.umc10th.global.apiPayload.code.BaseSuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MissionSuccessCode implements BaseSuccessCode {
+
+    MY_MISSIONS_OK(HttpStatus.OK, "MISSION_200_0", "내 미션 목록 조회 성공"),
+    HOME_MISSIONS_OK(HttpStatus.OK, "MISSION_200_1", "홈 미션 목록 조회 성공");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
 }
+

--- a/src/main/java/com/example/umc10th/domain/mission/repository/MissionRepository.java
+++ b/src/main/java/com/example/umc10th/domain/mission/repository/MissionRepository.java
@@ -1,0 +1,7 @@
+package com.example.umc10th.domain.mission.repository;
+
+import com.example.umc10th.domain.mission.entity.Mission;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MissionRepository extends JpaRepository<Mission, Long> {
+}

--- a/src/main/java/com/example/umc10th/domain/mission/repository/UserMissionRepository.java
+++ b/src/main/java/com/example/umc10th/domain/mission/repository/UserMissionRepository.java
@@ -1,0 +1,37 @@
+package com.example.umc10th.domain.mission.repository;
+
+import com.example.umc10th.domain.mission.entity.mapping.UserMission;
+import com.example.umc10th.domain.mission.enums.MissionStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface UserMissionRepository extends JpaRepository<UserMission, Long> {
+
+    boolean existsByUserIdAndMissionId(Long userId, Long missionId);
+
+    @Query("SELECT um FROM UserMission um " +
+            "JOIN FETCH um.mission m " +
+            "JOIN FETCH m.restaurant r " +
+            "WHERE um.user.id = :userId AND um.status = :status")
+    Page<UserMission> findByUserIdAndStatus(
+            @Param("userId") Long userId,
+            @Param("status") MissionStatus status,
+            Pageable pageable
+    );
+
+    // 홈 화면: 특정 지역에서 유저가 아직 도전하지 않은 미션 목록
+    @Query("SELECT m FROM Mission m " +
+            "JOIN FETCH m.restaurant r " +
+            "WHERE r.location.id = :locationId " +
+            "AND m.id NOT IN (" +
+            "   SELECT um.mission.id FROM UserMission um WHERE um.user.id = :userId" +
+            ")")
+    Page<com.example.umc10th.domain.mission.entity.Mission> findAvailableMissions(
+            @Param("userId") Long userId,
+            @Param("locationId") Long locationId,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/example/umc10th/domain/mission/repository/UserMissionRepository.java
+++ b/src/main/java/com/example/umc10th/domain/mission/repository/UserMissionRepository.java
@@ -22,6 +22,15 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
             Pageable pageable
     );
 
+    @Query("SELECT um FROM UserMission um " +
+            "JOIN FETCH um.mission m " +
+            "JOIN FETCH m.restaurant r " +
+            "WHERE um.user.id = :userId AND um.status = 'ONGOING'")
+    Page<UserMission> findOngoingMissionsByUserId(
+            @Param("userId") Long userId,
+            Pageable pageable
+    );
+
     // 홈 화면: 특정 지역에서 유저가 아직 도전하지 않은 미션 목록
     @Query("SELECT m FROM Mission m " +
             "JOIN FETCH m.restaurant r " +

--- a/src/main/java/com/example/umc10th/domain/mission/service/MissionService.java
+++ b/src/main/java/com/example/umc10th/domain/mission/service/MissionService.java
@@ -1,9 +1,12 @@
 package com.example.umc10th.domain.mission.service;
 
+import com.example.umc10th.domain.mission.dto.MemberMissionResDTO;
 import com.example.umc10th.domain.mission.dto.MissionResDTO;
 import com.example.umc10th.domain.mission.enums.MissionStatus;
 
 public interface MissionService {
     MissionResDTO.MyMissionListRes getMyMissions(Long userId, MissionStatus status, int page);
     MissionResDTO.HomeMissionListRes getHomeMissions(Long userId, Long locationId, int page);
+    MissionResDTO.OffsetPaginationRes<MemberMissionResDTO.OngoingMissionItem> getMissions(
+            Long memberId, Integer pageSize, Integer pageNumber, String sort);
 }

--- a/src/main/java/com/example/umc10th/domain/mission/service/MissionService.java
+++ b/src/main/java/com/example/umc10th/domain/mission/service/MissionService.java
@@ -1,0 +1,9 @@
+package com.example.umc10th.domain.mission.service;
+
+import com.example.umc10th.domain.mission.dto.MissionResDTO;
+import com.example.umc10th.domain.mission.enums.MissionStatus;
+
+public interface MissionService {
+    MissionResDTO.MyMissionListRes getMyMissions(Long userId, MissionStatus status, int page);
+    MissionResDTO.HomeMissionListRes getHomeMissions(Long userId, Long locationId, int page);
+}

--- a/src/main/java/com/example/umc10th/domain/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/example/umc10th/domain/mission/service/MissionServiceImpl.java
@@ -1,0 +1,66 @@
+package com.example.umc10th.domain.mission.service;
+
+import com.example.umc10th.domain.mission.dto.MissionResDTO;
+import com.example.umc10th.domain.mission.entity.Mission;
+import com.example.umc10th.domain.mission.entity.mapping.UserMission;
+import com.example.umc10th.domain.mission.enums.MissionStatus;
+import com.example.umc10th.domain.mission.repository.UserMissionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MissionServiceImpl implements MissionService {
+
+    private static final int PAGE_SIZE = 10;
+
+    private final UserMissionRepository userMissionRepository;
+
+    @Override
+    public MissionResDTO.MyMissionListRes getMyMissions(Long userId, MissionStatus status, int page) {
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+        Page<UserMission> result = userMissionRepository.findByUserIdAndStatus(userId, status, pageable);
+
+        List<MissionResDTO.MyMissionItem> items = result.getContent().stream()
+                .map(um -> MissionResDTO.MyMissionItem.builder()
+                        .restaurantName(um.getMission().getRestaurant().getName())
+                        .rewardPoint(um.getMission().getRewardPoint())
+                        .status(um.getStatus())
+                        .description(um.getMission().getDescription())
+                        .build())
+                .toList();
+
+        return MissionResDTO.MyMissionListRes.builder()
+                .missions(items)
+                .hasNext(result.hasNext())
+                .build();
+    }
+
+    @Override
+    public MissionResDTO.HomeMissionListRes getHomeMissions(Long userId, Long locationId, int page) {
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+        Page<Mission> result = userMissionRepository.findAvailableMissions(userId, locationId, pageable);
+
+        List<MissionResDTO.HomeMissionItem> items = result.getContent().stream()
+                .map(m -> MissionResDTO.HomeMissionItem.builder()
+                        .restaurantName(m.getRestaurant().getName())
+                        .description(m.getDescription())
+                        .rewardPoint(m.getRewardPoint())
+                        .successCount(0L)
+                        .totalCount(0L)
+                        .build())
+                .toList();
+
+        return MissionResDTO.HomeMissionListRes.builder()
+                .missions(items)
+                .hasNext(result.hasNext())
+                .build();
+    }
+}

--- a/src/main/java/com/example/umc10th/domain/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/example/umc10th/domain/mission/service/MissionServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.umc10th.domain.mission.service;
 
+import com.example.umc10th.domain.mission.converter.MissionConverter;
+import com.example.umc10th.domain.mission.dto.MemberMissionResDTO;
 import com.example.umc10th.domain.mission.dto.MissionResDTO;
 import com.example.umc10th.domain.mission.entity.Mission;
 import com.example.umc10th.domain.mission.entity.mapping.UserMission;
@@ -9,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,6 +44,23 @@ public class MissionServiceImpl implements MissionService {
                 .missions(items)
                 .hasNext(result.hasNext())
                 .build();
+    }
+
+    @Override
+    public MissionResDTO.OffsetPaginationRes<MemberMissionResDTO.OngoingMissionItem> getMissions(
+            Long memberId, Integer pageSize, Integer pageNumber, String sort) {
+        Sort sorting = (sort != null && !sort.isBlank())
+                ? Sort.by(Sort.Direction.DESC, sort)
+                : Sort.by(Sort.Direction.DESC, "id");
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, sorting);
+
+        Page<UserMission> page = userMissionRepository.findOngoingMissionsByUserId(memberId, pageable);
+
+        List<MemberMissionResDTO.OngoingMissionItem> items = page.getContent().stream()
+                .map(MissionConverter::toOngoingMissionItem)
+                .toList();
+
+        return MissionConverter.toPagination(items, pageNumber, pageSize);
     }
 
     @Override

--- a/src/main/java/com/example/umc10th/domain/restaurant/entity/Restaurant.java
+++ b/src/main/java/com/example/umc10th/domain/restaurant/entity/Restaurant.java
@@ -1,0 +1,40 @@
+package com.example.umc10th.domain.restaurant.entity;
+
+import com.example.umc10th.domain.food.entity.FoodCategory;
+import com.example.umc10th.domain.location.entity.Location;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "restaurant")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Restaurant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "restaurant_id")
+    private Long id;
+
+    @Column(nullable = false, length = 20)
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "food_category_id", nullable = false)
+    private FoodCategory foodCategory;
+
+    @Column(nullable = false, length = 100)
+    private String address;
+
+    @Column(columnDefinition = "FLOAT")
+    private Float rating;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_id", nullable = false)
+    private Location location;
+}

--- a/src/main/java/com/example/umc10th/domain/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/com/example/umc10th/domain/restaurant/repository/RestaurantRepository.java
@@ -1,0 +1,7 @@
+package com.example.umc10th.domain.restaurant.repository;
+
+import com.example.umc10th.domain.restaurant.entity.Restaurant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+}

--- a/src/main/java/com/example/umc10th/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/umc10th/domain/review/controller/ReviewController.java
@@ -1,23 +1,33 @@
 package com.example.umc10th.domain.review.controller;
 
-import com.example.umc10th.domain.review.exception.code.ReviewSuccessCode;
 import com.example.umc10th.domain.review.dto.ReviewReqDTO;
 import com.example.umc10th.domain.review.dto.ReviewResDTO;
+import com.example.umc10th.domain.review.exception.code.ReviewSuccessCode;
+import com.example.umc10th.domain.review.service.ReviewService;
 import com.example.umc10th.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "리뷰", description = "리뷰 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/stores")
 public class ReviewController {
 
-    // 리뷰 작성
+    private final ReviewService reviewService;
+
+    @Operation(summary = "리뷰 작성", description = "특정 가게에 리뷰를 작성합니다.")
     @PostMapping("/{storeId}/reviews")
     public ApiResponse<ReviewResDTO.CreateReviewRes> createReview(
-            @PathVariable Long storeId,
-            @RequestBody ReviewReqDTO.CreateReviewReq request
+            @Parameter(description = "가게 ID") @PathVariable Long storeId,
+            @Parameter(description = "작성자 유저 ID") @RequestParam Long userId,
+            @Valid @RequestBody ReviewReqDTO.CreateReviewReq request
     ) {
-        return ApiResponse.onSuccess(ReviewSuccessCode.REVIEW_CREATE_OK, null);
+        ReviewResDTO.CreateReviewRes result = reviewService.createReview(userId, storeId, request);
+        return ApiResponse.onSuccess(ReviewSuccessCode.REVIEW_CREATE_OK, result);
     }
 }

--- a/src/main/java/com/example/umc10th/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/example/umc10th/domain/review/converter/ReviewConverter.java
@@ -1,0 +1,28 @@
+package com.example.umc10th.domain.review.converter;
+
+import com.example.umc10th.domain.review.dto.ReviewResDTO;
+import com.example.umc10th.domain.review.entity.Review;
+
+import java.util.List;
+
+public class ReviewConverter {
+
+    public static ReviewResDTO.ReviewItemRes toReviewItemRes(Review review) {
+        return ReviewResDTO.ReviewItemRes.builder()
+                .reviewId(review.getId())
+                .score(review.getRating() != null ? review.getRating().floatValue() : null)
+                .body(review.getBody())
+                .createdAt(review.getCreatedAt() != null ? review.getCreatedAt().toLocalDate() : null)
+                .build();
+    }
+
+    public static <T> ReviewResDTO.CursorPaginationRes<T> toPagination(
+            List<T> data, Boolean hasNext, String nextCursor, Integer pageSize) {
+        return ReviewResDTO.CursorPaginationRes.<T>builder()
+                .data(data)
+                .hasNext(hasNext)
+                .nextCursor(nextCursor)
+                .pageSize(pageSize)
+                .build();
+    }
+}

--- a/src/main/java/com/example/umc10th/domain/review/dto/ReviewReqDTO.java
+++ b/src/main/java/com/example/umc10th/domain/review/dto/ReviewReqDTO.java
@@ -1,15 +1,29 @@
 package com.example.umc10th.domain.review.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
-import org.springframework.web.multipart.MultipartFile;
-import java.util.List;
 
 public class ReviewReqDTO {
 
     @Getter
+    @Schema(description = "리뷰 작성 요청")
     public static class CreateReviewReq {
+
+        @NotNull
+        @Min(1) @Max(5)
+        @Schema(description = "별점 (1~5)", example = "4")
         private Integer rating;
+
+        @NotBlank
+        @Schema(description = "리뷰 내용", example = "맛있었어요!")
         private String content;
-        private List<MultipartFile> images; // 선택
+
+        @NotNull
+        @Schema(description = "사용자 미션 ID", example = "1")
+        private Long userMissionId;
     }
 }

--- a/src/main/java/com/example/umc10th/domain/review/dto/ReviewResDTO.java
+++ b/src/main/java/com/example/umc10th/domain/review/dto/ReviewResDTO.java
@@ -1,16 +1,21 @@
 package com.example.umc10th.domain.review.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 public class ReviewResDTO {
 
     @Getter
+    @Builder
     @AllArgsConstructor
     public static class CreateReviewRes {
         private Long reviewId;
-        private Long storeId;
+        private String authorNickname;
         private Integer rating;
         private String content;
+        private LocalDateTime createdAt;
     }
 }

--- a/src/main/java/com/example/umc10th/domain/review/dto/ReviewResDTO.java
+++ b/src/main/java/com/example/umc10th/domain/review/dto/ReviewResDTO.java
@@ -4,7 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class ReviewResDTO {
 
@@ -17,5 +19,25 @@ public class ReviewResDTO {
         private Integer rating;
         private String content;
         private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ReviewItemRes {
+        private Long reviewId;
+        private Float score;
+        private String body;
+        private LocalDate createdAt;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class CursorPaginationRes<T> {
+        private List<T> data;
+        private Boolean hasNext;
+        private String nextCursor;
+        private Integer pageSize;
     }
 }

--- a/src/main/java/com/example/umc10th/domain/review/entity/Review.java
+++ b/src/main/java/com/example/umc10th/domain/review/entity/Review.java
@@ -1,0 +1,45 @@
+package com.example.umc10th.domain.review.entity;
+
+import com.example.umc10th.domain.mission.entity.mapping.UserMission;
+import com.example.umc10th.domain.restaurant.entity.Restaurant;
+import com.example.umc10th.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "review")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Review {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "restaurant_id")
+    private Restaurant restaurant;
+
+    private Integer rating;
+
+    @Column(length = 300)
+    private String body;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_mission_id", nullable = false)
+    private UserMission userMission;
+}

--- a/src/main/java/com/example/umc10th/domain/review/exception/code/ReviewErrorCode.java
+++ b/src/main/java/com/example/umc10th/domain/review/exception/code/ReviewErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ReviewErrorCode implements BaseErrorCode {
 
-    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_1", "존재하지 않는 리뷰입니다.");
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_1", "존재하지 않는 리뷰입니다."),
+    INVALID_SORT_TYPE(HttpStatus.BAD_REQUEST, "REVIEW400_1", "정렬 기준은 id 또는 star만 허용됩니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/umc10th/domain/review/exception/code/ReviewSuccessCode.java
+++ b/src/main/java/com/example/umc10th/domain/review/exception/code/ReviewSuccessCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ReviewSuccessCode implements BaseSuccessCode {
 
-    REVIEW_CREATE_OK(HttpStatus.CREATED, "REVIEW_201", "리뷰 작성 성공");
+    REVIEW_CREATE_OK(HttpStatus.CREATED, "REVIEW_201", "리뷰 작성 성공"),
+    REVIEWS_OK(HttpStatus.OK, "REVIEW_200_1", "내 리뷰 목록 조회 성공");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/umc10th/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/umc10th/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.example.umc10th.domain.review.repository;
+
+import com.example.umc10th.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/src/main/java/com/example/umc10th/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/umc10th/domain/review/repository/ReviewRepository.java
@@ -1,7 +1,45 @@
 package com.example.umc10th.domain.review.repository;
 
 import com.example.umc10th.domain.review.entity.Review;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    // ID 순 - 커서 없이
+    @Query("SELECT r FROM Review r WHERE r.user.id = :userId ORDER BY r.id DESC")
+    List<Review> findByUserIdOrderByIdDesc(
+            @Param("userId") Long userId,
+            Pageable pageable
+    );
+
+    // ID 순 - 커서 있을 때 (id < cursor)
+    @Query("SELECT r FROM Review r WHERE r.user.id = :userId AND r.id < :cursor ORDER BY r.id DESC")
+    List<Review> findByUserIdAndIdLessThanOrderByIdDesc(
+            @Param("userId") Long userId,
+            @Param("cursor") Long cursor,
+            Pageable pageable
+    );
+
+    // 별점 순 - 커서 없이
+    @Query("SELECT r FROM Review r WHERE r.user.id = :userId ORDER BY r.rating DESC, r.id DESC")
+    List<Review> findByUserIdOrderByRatingDescIdDesc(
+            @Param("userId") Long userId,
+            Pageable pageable
+    );
+
+    // 별점 순 - 커서 있을 때 (rating < cursorRating OR (rating = cursorRating AND id < cursorId))
+    @Query("SELECT r FROM Review r WHERE r.user.id = :userId " +
+            "AND (r.rating < :rating OR (r.rating = :rating AND r.id < :id)) " +
+            "ORDER BY r.rating DESC, r.id DESC")
+    List<Review> findByUserIdWithRatingCursor(
+            @Param("userId") Long userId,
+            @Param("rating") Integer rating,
+            @Param("id") Long id,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/example/umc10th/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/umc10th/domain/review/service/ReviewService.java
@@ -5,4 +5,6 @@ import com.example.umc10th.domain.review.dto.ReviewResDTO;
 
 public interface ReviewService {
     ReviewResDTO.CreateReviewRes createReview(Long userId, Long restaurantId, ReviewReqDTO.CreateReviewReq request);
+    ReviewResDTO.CursorPaginationRes<ReviewResDTO.ReviewItemRes> getReviews(
+            Long memberId, Integer pageSize, String cursor, String query);
 }

--- a/src/main/java/com/example/umc10th/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/umc10th/domain/review/service/ReviewService.java
@@ -1,0 +1,8 @@
+package com.example.umc10th.domain.review.service;
+
+import com.example.umc10th.domain.review.dto.ReviewReqDTO;
+import com.example.umc10th.domain.review.dto.ReviewResDTO;
+
+public interface ReviewService {
+    ReviewResDTO.CreateReviewRes createReview(Long userId, Long restaurantId, ReviewReqDTO.CreateReviewReq request);
+}

--- a/src/main/java/com/example/umc10th/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/example/umc10th/domain/review/service/ReviewServiceImpl.java
@@ -6,6 +6,7 @@ import com.example.umc10th.domain.restaurant.entity.Restaurant;
 import com.example.umc10th.domain.restaurant.exception.RestaurantException;
 import com.example.umc10th.domain.restaurant.exception.code.RestaurantErrorCode;
 import com.example.umc10th.domain.restaurant.repository.RestaurantRepository;
+import com.example.umc10th.domain.review.converter.ReviewConverter;
 import com.example.umc10th.domain.review.dto.ReviewReqDTO;
 import com.example.umc10th.domain.review.dto.ReviewResDTO;
 import com.example.umc10th.domain.review.entity.Review;
@@ -17,8 +18,12 @@ import com.example.umc10th.domain.user.exception.UserException;
 import com.example.umc10th.domain.user.exception.code.UserErrorCode;
 import com.example.umc10th.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -59,5 +64,57 @@ public class ReviewServiceImpl implements ReviewService {
                 .content(saved.getBody())
                 .createdAt(saved.getCreatedAt())
                 .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ReviewResDTO.CursorPaginationRes<ReviewResDTO.ReviewItemRes> getReviews(
+            Long memberId, Integer pageSize, String cursor, String query) {
+
+        if (!query.equals("id") && !query.equals("star")) {
+            throw new ReviewException(ReviewErrorCode.INVALID_SORT_TYPE);
+        }
+
+        Pageable pageable = PageRequest.of(0, pageSize + 1);
+        List<Review> reviews;
+
+        if (query.equals("id")) {
+            if (cursor.equals("-1")) {
+                reviews = reviewRepository.findByUserIdOrderByIdDesc(memberId, pageable);
+            } else {
+                // cursor 형식: "id:123"
+                Long cursorId = Long.parseLong(cursor.split(":")[1]);
+                reviews = reviewRepository.findByUserIdAndIdLessThanOrderByIdDesc(memberId, cursorId, pageable);
+            }
+        } else {
+            if (cursor.equals("-1")) {
+                reviews = reviewRepository.findByUserIdOrderByRatingDescIdDesc(memberId, pageable);
+            } else {
+                // cursor 형식: "star:4:123"
+                String[] parts = cursor.split(":");
+                Integer cursorRating = Integer.parseInt(parts[1]);
+                Long cursorId = Long.parseLong(parts[2]);
+                reviews = reviewRepository.findByUserIdWithRatingCursor(memberId, cursorRating, cursorId, pageable);
+            }
+        }
+
+        boolean hasNext = reviews.size() > pageSize;
+        List<Review> pageContent = hasNext ? reviews.subList(0, pageSize) : reviews;
+
+        String nextCursor = null;
+        if (hasNext) {
+            Review last = pageContent.get(pageContent.size() - 1);
+            if (query.equals("id")) {
+                nextCursor = "id:" + last.getId();
+            } else {
+                nextCursor = "star:" + last.getRating() + ":" + last.getId();
+            }
+        }
+
+        List<ReviewResDTO.ReviewItemRes> items = pageContent.stream()
+                .map(ReviewConverter::toReviewItemRes)
+                .toList();
+
+        return ReviewConverter.toPagination(items, hasNext, nextCursor, pageSize);
     }
 }

--- a/src/main/java/com/example/umc10th/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/example/umc10th/domain/review/service/ReviewServiceImpl.java
@@ -1,0 +1,63 @@
+package com.example.umc10th.domain.review.service;
+
+import com.example.umc10th.domain.mission.entity.mapping.UserMission;
+import com.example.umc10th.domain.mission.repository.UserMissionRepository;
+import com.example.umc10th.domain.restaurant.entity.Restaurant;
+import com.example.umc10th.domain.restaurant.exception.RestaurantException;
+import com.example.umc10th.domain.restaurant.exception.code.RestaurantErrorCode;
+import com.example.umc10th.domain.restaurant.repository.RestaurantRepository;
+import com.example.umc10th.domain.review.dto.ReviewReqDTO;
+import com.example.umc10th.domain.review.dto.ReviewResDTO;
+import com.example.umc10th.domain.review.entity.Review;
+import com.example.umc10th.domain.review.exception.ReviewException;
+import com.example.umc10th.domain.review.exception.code.ReviewErrorCode;
+import com.example.umc10th.domain.review.repository.ReviewRepository;
+import com.example.umc10th.domain.user.entity.User;
+import com.example.umc10th.domain.user.exception.UserException;
+import com.example.umc10th.domain.user.exception.code.UserErrorCode;
+import com.example.umc10th.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReviewServiceImpl implements ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final UserRepository userRepository;
+    private final RestaurantRepository restaurantRepository;
+    private final UserMissionRepository userMissionRepository;
+
+    @Override
+    public ReviewResDTO.CreateReviewRes createReview(Long userId, Long restaurantId,
+                                                      ReviewReqDTO.CreateReviewReq request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        Restaurant restaurant = restaurantRepository.findById(restaurantId)
+                .orElseThrow(() -> new RestaurantException(RestaurantErrorCode.RESTAURANT_NOT_FOUND));
+
+        UserMission userMission = userMissionRepository.findById(request.getUserMissionId())
+                .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND));
+
+        Review review = Review.builder()
+                .user(user)
+                .restaurant(restaurant)
+                .userMission(userMission)
+                .rating(request.getRating())
+                .body(request.getContent())
+                .build();
+
+        Review saved = reviewRepository.save(review);
+
+        return ReviewResDTO.CreateReviewRes.builder()
+                .reviewId(saved.getId())
+                .authorNickname(user.getNickname())
+                .rating(saved.getRating())
+                .content(saved.getBody())
+                .createdAt(saved.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/umc10th/domain/user/controller/AuthController.java
+++ b/src/main/java/com/example/umc10th/domain/user/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.example.umc10th.domain.user.dto.UserReqDTO;
 import com.example.umc10th.domain.user.dto.UserResDTO;
 import com.example.umc10th.domain.user.exception.code.UserSuccessCode;
 import com.example.umc10th.global.apiPayload.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,7 +16,7 @@ public class AuthController {
     // 회원가입
     @PostMapping("/users")
     public ApiResponse<UserResDTO.JoinRes> join(
-            @RequestBody UserReqDTO.JoinReq request
+            @Valid @RequestBody UserReqDTO.JoinReq request
     ) {
         return ApiResponse.onSuccess(UserSuccessCode.USER_JOIN_OK, null);
     }

--- a/src/main/java/com/example/umc10th/domain/user/controller/MemberController.java
+++ b/src/main/java/com/example/umc10th/domain/user/controller/MemberController.java
@@ -1,0 +1,60 @@
+package com.example.umc10th.domain.user.controller;
+
+import com.example.umc10th.domain.mission.dto.MemberMissionResDTO;
+import com.example.umc10th.domain.mission.dto.MissionResDTO;
+import com.example.umc10th.domain.mission.exception.code.MissionSuccessCode;
+import com.example.umc10th.domain.mission.service.MissionService;
+import com.example.umc10th.domain.review.dto.ReviewResDTO;
+import com.example.umc10th.domain.review.exception.code.ReviewSuccessCode;
+import com.example.umc10th.domain.review.service.ReviewService;
+import com.example.umc10th.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "멤버", description = "멤버 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/members")
+@Validated
+public class MemberController {
+
+    private final MissionService missionService;
+    private final ReviewService reviewService;
+
+    @Operation(
+            summary = "진행중인 미션 목록 조회",
+            description = "특정 멤버의 진행중인 미션 목록을 오프셋 기반 페이지네이션으로 조회합니다."
+    )
+    @GetMapping("/{memberId}/missions")
+    public ApiResponse<MissionResDTO.OffsetPaginationRes<MemberMissionResDTO.OngoingMissionItem>> getMissions(
+            @Parameter(description = "멤버 ID") @PathVariable Long memberId,
+            @Parameter(description = "페이지당 항목 수") @RequestParam(defaultValue = "10") @Min(1) Integer pageSize,
+            @Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(defaultValue = "0") @Min(0) Integer pageNumber,
+            @Parameter(description = "정렬 기준 필드 (선택, 없으면 id DESC)") @RequestParam(required = false) String sort
+    ) {
+        MissionResDTO.OffsetPaginationRes<MemberMissionResDTO.OngoingMissionItem> result =
+                missionService.getMissions(memberId, pageSize, pageNumber, sort);
+        return ApiResponse.onSuccess(MissionSuccessCode.ONGOING_MISSIONS_OK, result);
+    }
+
+    @Operation(
+            summary = "내 리뷰 목록 조회",
+            description = "특정 멤버가 작성한 리뷰 목록을 커서 기반 페이지네이션으로 조회합니다. query: id(ID순) 또는 star(별점순)"
+    )
+    @GetMapping("/{memberId}/reviews")
+    public ApiResponse<ReviewResDTO.CursorPaginationRes<ReviewResDTO.ReviewItemRes>> getReviews(
+            @Parameter(description = "멤버 ID") @PathVariable Long memberId,
+            @Parameter(description = "페이지당 항목 수") @RequestParam(defaultValue = "10") @Min(1) Integer pageSize,
+            @Parameter(description = "커서 값 (첫 페이지는 -1)") @RequestParam(defaultValue = "-1") String cursor,
+            @Parameter(description = "정렬 기준 (id 또는 star)") @RequestParam(defaultValue = "id") String query
+    ) {
+        ReviewResDTO.CursorPaginationRes<ReviewResDTO.ReviewItemRes> result =
+                reviewService.getReviews(memberId, pageSize, cursor, query);
+        return ApiResponse.onSuccess(ReviewSuccessCode.REVIEWS_OK, result);
+    }
+}

--- a/src/main/java/com/example/umc10th/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/umc10th/domain/user/controller/UserController.java
@@ -9,6 +9,7 @@ import com.example.umc10th.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -47,7 +48,7 @@ public class UserController {
     @PatchMapping("/me/missions/{userMissionId}")
     public ApiResponse<UserResDTO.MissionChallengeRes> successMission(
             @PathVariable Long userMissionId,
-            @RequestBody UserReqDTO.MissionSuccessReq request
+            @Valid @RequestBody UserReqDTO.MissionSuccessReq request
     ) {
         return ApiResponse.onSuccess(UserSuccessCode.USER_MISSION_SUCCESS_OK, null);
     }

--- a/src/main/java/com/example/umc10th/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/umc10th/domain/user/controller/UserController.java
@@ -4,46 +4,47 @@ import com.example.umc10th.domain.mission.enums.MissionStatus;
 import com.example.umc10th.domain.user.dto.UserReqDTO;
 import com.example.umc10th.domain.user.dto.UserResDTO;
 import com.example.umc10th.domain.user.exception.code.UserSuccessCode;
+import com.example.umc10th.domain.user.service.UserService;
 import com.example.umc10th.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-import java.util.List;
 
+@Tag(name = "사용자", description = "사용자 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/users/me")
+@RequestMapping("/api/users")
 public class UserController {
 
-    // 사용자 정보 및 포인트 조회
-    @GetMapping
-    public ApiResponse<UserResDTO.UserInfoRes> getUserInfo() {
-        return ApiResponse.onSuccess(UserSuccessCode.USER_INFO_OK, null);
+    private final UserService userService;
+
+    @Operation(summary = "마이페이지 조회", description = "내 닉네임, 이메일, 전화번호, 포인트를 조회합니다.")
+    @GetMapping("/me")
+    public ApiResponse<UserResDTO.MyPageRes> getMyPage(
+            @Parameter(description = "유저 ID") @RequestParam Long userId
+    ) {
+        UserResDTO.MyPageRes result = userService.getMyPage(userId);
+        return ApiResponse.onSuccess(UserSuccessCode.USER_MYPAGE_OK, result);
     }
 
-    // 미션 진행 현황 조회
-    @GetMapping("/mission-progress")
+    @Operation(summary = "미션 진행 현황 조회")
+    @GetMapping("/me/mission-progress")
     public ApiResponse<UserResDTO.MissionProgressRes> getMissionProgress() {
         return ApiResponse.onSuccess(UserSuccessCode.USER_MISSION_PROGRESS_OK, null);
     }
 
-    // 내가 받은 미션 목록 조회 + 미션 목록 조회 (status 필터)
-    @GetMapping("/missions")
-    public ApiResponse<List<UserResDTO.MissionRes>> getMyMissions(
-            @RequestParam(required = false) MissionStatus status
-    ) {
-        return ApiResponse.onSuccess(UserSuccessCode.USER_MISSIONS_OK, null);
-    }
-
-    // 미션 도전하기
-    @PostMapping("/missions/{missionId}/challenge")
+    @Operation(summary = "미션 도전하기")
+    @PostMapping("/me/missions/{missionId}/challenge")
     public ApiResponse<UserResDTO.MissionChallengeRes> challengeMission(
             @PathVariable Long missionId
     ) {
         return ApiResponse.onSuccess(UserSuccessCode.USER_MISSION_CHALLENGE_OK, null);
     }
 
-    // 미션 성공 누르기
-    @PatchMapping("/missions/{userMissionId}")
+    @Operation(summary = "미션 성공 처리")
+    @PatchMapping("/me/missions/{userMissionId}")
     public ApiResponse<UserResDTO.MissionChallengeRes> successMission(
             @PathVariable Long userMissionId,
             @RequestBody UserReqDTO.MissionSuccessReq request

--- a/src/main/java/com/example/umc10th/domain/user/dto/UserReqDTO.java
+++ b/src/main/java/com/example/umc10th/domain/user/dto/UserReqDTO.java
@@ -1,25 +1,50 @@
 package com.example.umc10th.domain.user.dto;
 
 import com.example.umc10th.domain.mission.enums.MissionStatus;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
+
 import java.time.LocalDate;
 
 public class UserReqDTO {
 
     @Getter
     public static class JoinReq {
+
+        @NotBlank(message = "이름은 필수입니다.")
         private String name;
+
+        @NotBlank(message = "성별은 필수입니다.")
         private String gender;
+
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
         private String email;
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
         private String password;
+
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(max = 20, message = "닉네임은 20자 이하여야 합니다.")
         private String nickname;
+
+        @NotBlank(message = "주소는 필수입니다.")
         private String address;
+
+        @NotNull(message = "생년월일은 필수입니다.")
         private LocalDate birth;
-        private String phone; // 선택
+
+        private String phone;
     }
 
     @Getter
     public static class MissionSuccessReq {
+
+        @NotNull(message = "미션 상태는 필수입니다.")
         private MissionStatus status;
     }
 }

--- a/src/main/java/com/example/umc10th/domain/user/dto/UserResDTO.java
+++ b/src/main/java/com/example/umc10th/domain/user/dto/UserResDTO.java
@@ -2,16 +2,27 @@ package com.example.umc10th.domain.user.dto;
 
 import com.example.umc10th.domain.mission.enums.MissionStatus;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import java.util.List;
 
 public class UserResDTO {
 
+    // 마이페이지
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class MyPageRes {
+        private String nickname;
+        private String email;
+        private String phoneNum;
+        private Integer point;
+    }
+
+    // 기존 컨트롤러 호환용
     @Getter
     @AllArgsConstructor
     public static class UserInfoRes {
         private Long userId;
-        private String name;
         private String nickname;
         private Integer point;
     }
@@ -41,10 +52,10 @@ public class UserResDTO {
     }
 
     @Getter
+    @Builder
     @AllArgsConstructor
     public static class JoinRes {
         private Long userId;
-        private String name;
         private String email;
     }
 }

--- a/src/main/java/com/example/umc10th/domain/user/entity/User.java
+++ b/src/main/java/com/example/umc10th/domain/user/entity/User.java
@@ -1,0 +1,56 @@
+package com.example.umc10th.domain.user.entity;
+
+import com.example.umc10th.domain.user.enums.Gender;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(nullable = false, length = 20)
+    private String nickname;
+
+    @Column(nullable = false, length = 20)
+    private String email;
+
+    @Column(nullable = false, length = 100)
+    private String password;
+
+    @Column(name = "phone_num", length = 11)
+    private String phoneNum;
+
+    @Builder.Default
+    private Integer point = 0;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @Column(name = "birth_date", nullable = false)
+    private LocalDate birthDate;
+
+    @Column(length = 100)
+    private String address;
+
+    @CreationTimestamp
+    @Column(name = "create_date", nullable = false, updatable = false)
+    private LocalDateTime createDate;
+
+    @Column(name = "delete_date")
+    private LocalDateTime deleteDate;
+}

--- a/src/main/java/com/example/umc10th/domain/user/enums/Gender.java
+++ b/src/main/java/com/example/umc10th/domain/user/enums/Gender.java
@@ -1,0 +1,5 @@
+package com.example.umc10th.domain.user.enums;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/src/main/java/com/example/umc10th/domain/user/exception/code/UserSuccessCode.java
+++ b/src/main/java/com/example/umc10th/domain/user/exception/code/UserSuccessCode.java
@@ -9,12 +9,13 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserSuccessCode implements BaseSuccessCode {
 
-    USER_INFO_OK(HttpStatus.OK, "200_0", "사용자 정보 조회 성공"),
-    USER_MISSION_PROGRESS_OK(HttpStatus.OK, "200_1", "미션 진행 현황 조회 성공"),
-    USER_MISSIONS_OK(HttpStatus.OK, "200_2", "미션 목록 조회 성공"),
-    USER_MISSION_CHALLENGE_CREATED(HttpStatus.CREATED, "200_3", "미션 도전 성공"),
-    USER_MISSION_SUCCESS_OK(HttpStatus.OK, "200_4", "미션 성공 처리 완료"),
-    USER_JOIN_CREATED(HttpStatus.CREATED, "201_0", "회원가입 성공");
+    USER_INFO_OK(HttpStatus.OK, "USER_200_0", "사용자 정보 조회 성공"),
+    USER_MYPAGE_OK(HttpStatus.OK, "USER_200_1", "마이페이지 조회 성공"),
+    USER_MISSION_PROGRESS_OK(HttpStatus.OK, "USER_200_2", "미션 진행 현황 조회 성공"),
+    USER_MISSIONS_OK(HttpStatus.OK, "USER_200_3", "미션 목록 조회 성공"),
+    USER_MISSION_CHALLENGE_OK(HttpStatus.CREATED, "USER_201_0", "미션 도전 성공"),
+    USER_MISSION_SUCCESS_OK(HttpStatus.OK, "USER_200_4", "미션 성공 처리 완료"),
+    USER_JOIN_OK(HttpStatus.CREATED, "USER_201_1", "회원가입 성공");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/umc10th/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/umc10th/domain/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.example.umc10th.domain.user.repository;
+
+import com.example.umc10th.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/example/umc10th/domain/user/service/UserService.java
+++ b/src/main/java/com/example/umc10th/domain/user/service/UserService.java
@@ -1,0 +1,7 @@
+package com.example.umc10th.domain.user.service;
+
+import com.example.umc10th.domain.user.dto.UserResDTO;
+
+public interface UserService {
+    UserResDTO.MyPageRes getMyPage(Long userId);
+}

--- a/src/main/java/com/example/umc10th/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/umc10th/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,31 @@
+package com.example.umc10th.domain.user.service;
+
+import com.example.umc10th.domain.user.dto.UserResDTO;
+import com.example.umc10th.domain.user.entity.User;
+import com.example.umc10th.domain.user.exception.UserException;
+import com.example.umc10th.domain.user.exception.code.UserErrorCode;
+import com.example.umc10th.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserResDTO.MyPageRes getMyPage(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        return UserResDTO.MyPageRes.builder()
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .phoneNum(user.getPhoneNum())
+                .point(user.getPoint())
+                .build();
+    }
+}

--- a/src/main/java/com/example/umc10th/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/example/umc10th/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GeneralExceptionAdvice {
-    @ExceptionHandler(Exception.class)
+    @ExceptionHandler(ProjectException.class)
     public ResponseEntity<ApiResponse<Void>> handleMemberException(
             ProjectException e
     ){

--- a/src/main/java/com/example/umc10th/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/example/umc10th/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -5,18 +5,35 @@ import com.example.umc10th.global.apiPayload.code.BaseErrorCode;
 import com.example.umc10th.global.apiPayload.code.GeneralErrorCode;
 import com.example.umc10th.global.apiPayload.exception.ProjectException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 @RestControllerAdvice
 public class GeneralExceptionAdvice {
+
     @ExceptionHandler(ProjectException.class)
     public ResponseEntity<ApiResponse<Void>> handleMemberException(
             ProjectException e
-    ){
+    ) {
         BaseErrorCode errorCode = e.getErrorCode();
         return ResponseEntity.status(errorCode.getStatus())
                 .body(ApiResponse.onFailure(errorCode, null));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleValidationException(
+            MethodArgumentNotValidException e
+    ) {
+        Map<String, String> errors = new LinkedHashMap<>();
+        e.getBindingResult().getFieldErrors().forEach(fieldError ->
+                errors.put(fieldError.getField(), fieldError.getDefaultMessage())
+        );
+        return ResponseEntity.status(GeneralErrorCode.BAD_REQUEST.getStatus())
+                .body(ApiResponse.onFailure(GeneralErrorCode.BAD_REQUEST, errors));
     }
 
     @ExceptionHandler(Exception.class)
@@ -28,7 +45,6 @@ public class GeneralExceptionAdvice {
                 .body(ApiResponse.onFailure(
                         code,
                         ex.getMessage()
-                        )
-                );
+                ));
     }
 }


### PR DESCRIPTION
## ✅ 워크북 체크리스트

- [x] 모든 핵심 키워드 정리를 마쳤나요?
- [x] 핵심 키워드에 대해 완벽히 이해하셨나요?
- [x] 이론 학습 이후 직접 실습을 해보는 시간을 가졌나요?
- [x] 미션을 수행하셨나요?
- [x] 미션을 기록하셨나요?
<br>

## ✅ 컨벤션 체크리스트

- [x] 디렉토리 구조 컨벤션을 잘 지켰나요?
- [x] pr 제목을 컨벤션에 맞게 작성하였나요?
- [x] pr에 해당되는 이슈를 연결하였나요?
- [x] 적절한 라벨을 설정하였나요?
- [x] 스터디원들에게 code review를 요청하기 위해 reviewer를 등록하였나요?
- [x] 닉네임/main 브랜치의 최신 상태를 반영하고 있는지 확인했나요?
<br>

## 📌 주안점

미션 1 - 오프셋 기반 페이지네이션
GET /api/v1/members/{memberId}/missions으로 진행중인 미션 목록을 조회합니다. pageSize, pageNumber, sort 파라미터를 받으며 sort가 없으면 id DESC로 정렬됩니다. MissionConverter를 통해 Entity → DTO 변환을 분리했습니다.

미션 2 - 커서 기반 페이지네이션
GET /api/v1/members/{memberId}/reviews으로 내가 작성한 리뷰를 조회합니다. query=id이면 ID 순, query=star이면 별점 순으로 정렬되며, 커서 형식은 ID 순일 때 id:123, 별점 순일 때 star:4:123입니다. 동점 처리를 위해 별점 순에서 id를 tie-break 기준으로 사용했습니다.

미션 3 - 검증 어노테이션
JoinReq에 @NotBlank, @Email, @Size 등을 적용하고, GeneralExceptionAdvice에 MethodArgumentNotValidException 핸들러를 추가해 검증 실패 시 필드명과 실패 이유를 Map 형태로 응답하도록 구현했습니다.