### PR TITLE
[Mins] Chapter 7. API 설계 심화 - 페이징

### DIFF
--- a/src/main/java/com/example/umc10th/domain/mission/controller/MissionController.java
+++ b/src/main/java/com/example/umc10th/domain/mission/controller/MissionController.java
@@ -22,7 +22,10 @@ public class MissionController {
             @RequestParam MissionStatus status,
             @RequestParam(defaultValue = "0") int page
     ) {
-        return ApiResponse.onSuccess(SuccessStatus._OK, missionService.getMissionList(memberId, status, page));
+        return ApiResponse.onSuccess(
+                SuccessStatus._OK,
+                missionService.getMissionList(memberId, status, page)
+        );
     }
 
     @PatchMapping("/me/missions/{missionId}")

--- a/src/main/java/com/example/umc10th/domain/mission/dto/MissionReqDTO.java
+++ b/src/main/java/com/example/umc10th/domain/mission/dto/MissionReqDTO.java
@@ -1,5 +1,12 @@
 package com.example.umc10th.domain.mission.dto;
 
+import jakarta.validation.constraints.NotNull;
+
 public class MissionReqDTO {
 
+    // 진행중인 미션 조회 요청
+    public record GetMyMissions(
+            @NotNull(message = "회원 ID는 필수입니다.")
+            Long memberId
+    ) {}
 }

--- a/src/main/java/com/example/umc10th/domain/mission/dto/MissionResDTO.java
+++ b/src/main/java/com/example/umc10th/domain/mission/dto/MissionResDTO.java
@@ -5,11 +5,7 @@ import java.util.List;
 
 public class MissionResDTO {
 
-    public record MissionListResult(
-            List<MissionDetail> missionList,
-            Integer totalCount
-    ) {}
-
+    // 기존 유지
     public record MissionDetail(
             Long missionId,
             String storeName,
@@ -22,5 +18,15 @@ public class MissionResDTO {
             Long missionId,
             String status,
             LocalDateTime completedAt
+    ) {}
+
+    // 오프셋 기반 페이지네이션 응답으로 변경
+    public record MissionListResult(
+            List<MissionDetail> missionList,
+            Integer pageNumber,
+            Integer pageSize,
+            Long totalCount,
+            Integer totalPages,
+            Boolean hasNext
     ) {}
 }

--- a/src/main/java/com/example/umc10th/domain/mission/service/MissionService.java
+++ b/src/main/java/com/example/umc10th/domain/mission/service/MissionService.java
@@ -25,13 +25,16 @@ public class MissionService {
     private final UserMissionRepository userMissionRepository;
     private final MemberRepository memberRepository;
 
-    // 내 미션 목록 조회 (진행중, 진행완료)
-    public MissionResDTO.MissionListResult getMissionList(Long memberId, MissionStatus status, int page) {
+    // 내 미션 목록 조회 (오프셋 기반)
+    public MissionResDTO.MissionListResult getMissionList(
+            Long memberId, MissionStatus status, int page) {
+
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 회원입니다."));
 
+        PageRequest pageRequest = PageRequest.of(page, 10);
         Page<UserMission> userMissions = userMissionRepository
-                .findByMemberAndStatus(member, status, PageRequest.of(page, 10));
+                .findByMemberAndStatus(member, status, pageRequest);
 
         List<MissionResDTO.MissionDetail> missionDetails = userMissions.stream()
                 .map(um -> new MissionResDTO.MissionDetail(
@@ -42,7 +45,14 @@ public class MissionService {
                         um.getStatus().name()
                 )).toList();
 
-        return new MissionResDTO.MissionListResult(missionDetails, (int) userMissions.getTotalElements());
+        return new MissionResDTO.MissionListResult(
+                missionDetails,
+                userMissions.getNumber(),
+                userMissions.getSize(),
+                userMissions.getTotalElements(),
+                userMissions.getTotalPages(),
+                userMissions.hasNext()
+        );
     }
 
     // 미션 완료 처리
@@ -60,8 +70,9 @@ public class MissionService {
 
     // 홈화면 - 특정 지역 미션 목록 조회
     public MissionResDTO.MissionListResult getHomeMissions(Long locationId, int page) {
+        PageRequest pageRequest = PageRequest.of(page, 10);
         Page<Mission> missions = missionRepository
-                .findMissionsByLocation(locationId, PageRequest.of(page, 10));
+                .findMissionsByLocation(locationId, pageRequest);
 
         List<MissionResDTO.MissionDetail> missionDetails = missions.stream()
                 .map(m -> new MissionResDTO.MissionDetail(
@@ -72,6 +83,13 @@ public class MissionService {
                         null
                 )).toList();
 
-        return new MissionResDTO.MissionListResult(missionDetails, (int) missions.getTotalElements());
+        return new MissionResDTO.MissionListResult(
+                missionDetails,
+                missions.getNumber(),
+                missions.getSize(),
+                missions.getTotalElements(),
+                missions.getTotalPages(),
+                missions.hasNext()
+        );
     }
 }

--- a/src/main/java/com/example/umc10th/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/umc10th/domain/review/controller/ReviewController.java
@@ -4,9 +4,10 @@ import com.example.umc10th.domain.review.dto.ReviewReqDTO;
 import com.example.umc10th.domain.review.dto.ReviewResDTO;
 import com.example.umc10th.domain.review.service.ReviewService;
 import com.example.umc10th.global.handler.ApiResponse;
+import com.example.umc10th.global.handler.SuccessStatus;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-import com.example.umc10th.global.handler.SuccessStatus;
 
 @RestController
 @RequiredArgsConstructor
@@ -15,11 +16,30 @@ public class ReviewController {
 
     private final ReviewService reviewService;
 
+    // 리뷰 생성
     @PostMapping("/me/reviews")
     public ApiResponse<ReviewResDTO.ReviewCreateResult> createReview(
             @RequestParam Long memberId,
-            @RequestBody ReviewReqDTO.ReviewCreate request
+            @RequestBody @Valid ReviewReqDTO.ReviewCreate request
     ) {
-        return ApiResponse.onSuccess(SuccessStatus._OK, reviewService.createReview(memberId, request));
+        return ApiResponse.onSuccess(
+                SuccessStatus._OK,
+                reviewService.createReview(memberId, request)
+        );
+    }
+
+    // 내가 생성한 리뷰 조회 (커서 기반)
+    // query = "id" or "star"
+    @GetMapping("/me/reviews")
+    public ApiResponse<ReviewResDTO.ReviewListResult> getMyReviews(
+            @RequestParam Long memberId,
+            @RequestParam(defaultValue = "10") int pageSize,
+            @RequestParam(defaultValue = "-1") String cursor,
+            @RequestParam(defaultValue = "id") String query
+    ) {
+        return ApiResponse.onSuccess(
+                SuccessStatus._OK,
+                reviewService.getMyReviews(memberId, pageSize, cursor, query)
+        );
     }
 }

--- a/src/main/java/com/example/umc10th/domain/review/dto/ReviewReqDTO.java
+++ b/src/main/java/com/example/umc10th/domain/review/dto/ReviewReqDTO.java
@@ -1,10 +1,22 @@
 package com.example.umc10th.domain.review.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public class ReviewReqDTO {
 
     public record ReviewCreate(
+            @NotNull(message = "가게 ID는 필수입니다.")
             Long storeId,
+
+            @NotNull(message = "별점은 필수입니다.")
+            @Min(value = 1, message = "별점은 1점 이상이어야 합니다.")
+            @Max(value = 5, message = "별점은 5점 이하여야 합니다.")
             Float score,
+
+            @NotBlank(message = "리뷰 내용은 빈칸일 수 없습니다.")
             String body
     ) {}
 }

--- a/src/main/java/com/example/umc10th/domain/review/dto/ReviewResDTO.java
+++ b/src/main/java/com/example/umc10th/domain/review/dto/ReviewResDTO.java
@@ -1,11 +1,28 @@
 package com.example.umc10th.domain.review.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class ReviewResDTO {
 
     public record ReviewCreateResult(
             Long reviewId,
             LocalDateTime createdAt
+    ) {}
+
+    public record ReviewDetail(
+            Long reviewId,
+            String storeName,
+            Float star,
+            String content,
+            LocalDateTime createdAt
+    ) {}
+
+    // 커서 기반 페이지네이션 응답
+    public record ReviewListResult(
+            List<ReviewDetail> reviewList,
+            Boolean hasNext,
+            String nextCursor,
+            Integer pageSize
     ) {}
 }

--- a/src/main/java/com/example/umc10th/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/umc10th/domain/review/repository/ReviewRepository.java
@@ -1,10 +1,46 @@
 package com.example.umc10th.domain.review.repository;
 
 import com.example.umc10th.domain.review.entity.Review;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
+    // ID 순 커서 기반 조회
+    @Query("SELECT r FROM Review r WHERE r.member.id = :memberId AND r.id < :idCursor ORDER BY r.id DESC")
+    Slice<Review> findByMemberIdAndIdLessThan(
+            @Param("memberId") Long memberId,
+            @Param("idCursor") Long idCursor,
+            Pageable pageable
+    );
+
+    // ID 순 첫 조회 (커서 없을 때)
+    @Query("SELECT r FROM Review r WHERE r.member.id = :memberId ORDER BY r.id DESC")
+    Slice<Review> findByMemberIdOrderByIdDesc(
+            @Param("memberId") Long memberId,
+            Pageable pageable
+    );
+
+    // 별점 순 커서 기반 조회
+    @Query("SELECT r FROM Review r WHERE r.member.id = :memberId " +
+            "AND (r.star < :starCursor OR (r.star = :starCursor AND r.id < :idCursor)) " +
+            "ORDER BY r.star DESC, r.id DESC")
+    Slice<Review> findByMemberIdAndStarCursor(
+            @Param("memberId") Long memberId,
+            @Param("starCursor") Float starCursor,
+            @Param("idCursor") Long idCursor,
+            Pageable pageable
+    );
+
+    // 별점 순 첫 조회 (커서 없을 때)
+    @Query("SELECT r FROM Review r WHERE r.member.id = :memberId ORDER BY r.star DESC, r.id DESC")
+    Slice<Review> findByMemberIdOrderByStarDesc(
+            @Param("memberId") Long memberId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/example/umc10th/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/umc10th/domain/review/service/ReviewService.java
@@ -9,8 +9,12 @@ import com.example.umc10th.domain.review.dto.ReviewResDTO;
 import com.example.umc10th.domain.review.entity.Review;
 import com.example.umc10th.domain.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,8 +25,11 @@ public class ReviewService {
     private final MemberRepository memberRepository;
     private final StoreRepository storeRepository;
 
+    // 리뷰 생성
     @Transactional
-    public ReviewResDTO.ReviewCreateResult createReview(Long memberId, ReviewReqDTO.ReviewCreate request) {
+    public ReviewResDTO.ReviewCreateResult createReview(
+            Long memberId, ReviewReqDTO.ReviewCreate request) {
+
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 회원입니다."));
 
@@ -41,6 +48,69 @@ public class ReviewService {
         return new ReviewResDTO.ReviewCreateResult(
                 savedReview.getId(),
                 savedReview.getCreatedAt()
+        );
+    }
+
+    // 내가 생성한 리뷰 조회 (커서 기반)
+    public ReviewResDTO.ReviewListResult getMyReviews(
+            Long memberId, int pageSize, String cursor, String query) {
+
+        PageRequest pageRequest = PageRequest.of(0, pageSize);
+        Slice<Review> reviewSlice;
+        String nextCursor;
+
+        // 커서가 있는 경우
+        if (!cursor.equals("-1")) {
+            String[] cursorSplit = cursor.split(":");
+
+            switch (query.toLowerCase()) {
+                case "id" -> {
+                    Long idCursor = Long.parseLong(cursorSplit[1]);
+                    reviewSlice = reviewRepository
+                            .findByMemberIdAndIdLessThan(memberId, idCursor, pageRequest);
+                }
+                case "star" -> {
+                    Float starCursor = Float.parseFloat(cursorSplit[0]);
+                    Long idCursor = Long.parseLong(cursorSplit[1]);
+                    reviewSlice = reviewRepository
+                            .findByMemberIdAndStarCursor(memberId, starCursor, idCursor, pageRequest);
+                }
+                default -> throw new RuntimeException("지원하지 않는 정렬 방식입니다.");
+            }
+        } else {
+            // 커서가 없는 경우 (첫 조회)
+            reviewSlice = switch (query.toLowerCase()) {
+                case "id" -> reviewRepository
+                        .findByMemberIdOrderByIdDesc(memberId, pageRequest);
+                case "star" -> reviewRepository
+                        .findByMemberIdOrderByStarDesc(memberId, pageRequest);
+                default -> throw new RuntimeException("지원하지 않는 정렬 방식입니다.");
+            };
+        }
+
+        // 다음 커서 계산
+        if (reviewSlice.hasNext()) {
+            Review lastReview = reviewSlice.getContent()
+                    .get(reviewSlice.getContent().size() - 1);
+            nextCursor = lastReview.getStar() + ":" + lastReview.getId();
+        } else {
+            nextCursor = null;
+        }
+
+        List<ReviewResDTO.ReviewDetail> reviewDetails = reviewSlice.stream()
+                .map(r -> new ReviewResDTO.ReviewDetail(
+                        r.getId(),
+                        r.getStore().getName(),
+                        r.getStar(),
+                        r.getContent(),
+                        r.getCreatedAt()
+                )).toList();
+
+        return new ReviewResDTO.ReviewListResult(
+                reviewDetails,
+                reviewSlice.hasNext(),
+                nextCursor,
+                reviewSlice.getSize()
         );
     }
 }

--- a/src/main/java/com/example/umc10th/global/handler/ExceptionAdvice.java
+++ b/src/main/java/com/example/umc10th/global/handler/ExceptionAdvice.java
@@ -2,12 +2,18 @@ package com.example.umc10th.global.handler;
 
 import com.example.umc10th.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RestControllerAdvice
 public class ExceptionAdvice {
 
+    // 기존 핸들러 유지
     @ExceptionHandler(GeneralException.class)
     public ApiResponse<?> handleGeneralException(GeneralException e) {
         return ApiResponse.onFailure(e.getCode(), null);
@@ -16,5 +22,23 @@ public class ExceptionAdvice {
     @ExceptionHandler(Exception.class)
     public ApiResponse<?> handleException(Exception e) {
         return ApiResponse.onFailure(GeneralErrorCode.INTERNAL_ERROR, null);
+    }
+
+    // @Valid 검증 실패 핸들러 추가
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Map<String, String>>>
+    handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+
+        // 검증 실패한 필드명 : 에러메시지 담기
+        Map<String, String> errors = new HashMap<>();
+        e.getBindingResult().getFieldErrors()
+                .forEach(error -> errors.put(
+                        error.getField(),
+                        error.getDefaultMessage()
+                ));
+
+        return ResponseEntity
+                .status(400)
+                .body(ApiResponse.onFailure(GeneralErrorCode.BAD_REQUEST, errors));
     }
 }


### PR DESCRIPTION
<!--
  제목은 `[닉네임] 챕터 제목` 로 작성해 주세요.
  예시: [Angela] Chapter 1. 서버란 무엇인가(소켓&멀티 프로세스)
-->

## ✅ 워크북 체크리스트

- [x] 모든 핵심 키워드 정리를 마쳤나요?
- [x] 핵심 키워드에 대해 완벽히 이해하셨나요?
- [x] 이론 학습 이후 직접 실습을 해보는 시간을 가졌나요?
- [x] 미션을 수행하셨나요?
- [x] 미션을 기록하셨나요?
<br>

## ✅ 컨벤션 체크리스트

- [x] 디렉토리 구조 컨벤션을 잘 지켰나요?
- [x] pr 제목을 컨벤션에 맞게 작성하였나요?
- [x] pr에 해당되는 이슈를 연결하였나요?
- [x] 적절한 라벨을 설정하였나요?
- [x] 스터디원들에게 code review를 요청하기 위해 reviewer를 등록하였나요?
- [x] 닉네임/main 브랜치의 최신 상태를 반영하고 있는지 확인했나요?
<br>

## 📌 주안점

<!--
 1. GET 요청에 RequestBody 사용 불가 문제

- 처음에 memberId를 RequestBody로 받도록 구현했으나 GET 요청은 Body를 가질 수 없어 RequestParam으로 변경했습니다.

2. 커서 기반 페이지네이션 설계

- 커서 형태를 star:id 로 직접 설계하여 ID순/별점순 두 가지 정렬을 하나의 커서 구조로 처리했습니다.
- 별점이 동일한 경우 ID 기준으로 추가 정렬하는 복합 커서를 구현했습니다.


3. Slice를 활용한 커서 기반 페이지네이션

- Slice는 다음 페이지 존재 여부(hasNext)만 제공하므로 커서 파싱, WHERE절 조건, nextCursor 계산은 직접 구현했습니다.


4. 검증 어노테이션과 ExceptionAdvice 연동

- @Valid 검증 실패 시 발생하는 MethodArgumentNotValidException을 ExceptionAdvice에서 잡아 필드별 한국어 에러 메시지로 응답하도록 처리했습니다.

-->
