### PR TITLE
[Dominic] Chapter 8. Spring Security - Security 구조, 폼 로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	//implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'

--- a/src/main/java/com/example/demo/domain/member/entity/Member.java
+++ b/src/main/java/com/example/demo/domain/member/entity/Member.java
@@ -38,7 +38,7 @@ public class Member extends SoftDeleteBaseEntity {
     private String nickname;
 
     // 로그인 또는 회원 식별에 사용할 이메일입니다.
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false, unique = true, length = 100)
     private String email;
 
     // 실제 서비스에서는 반드시 암호화된 비밀번호를 저장해야 합니다.

--- a/src/main/java/com/example/demo/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/example/demo/domain/member/exception/MemberErrorCode.java
@@ -13,7 +13,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum MemberErrorCode implements BaseErrorCode {
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "Member not found");
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "Member not found"),
+    MEMBER_EMAIL_DUPLICATED(HttpStatus.CONFLICT, "MEMBER409", "Email already exists");
 
     // GlobalExceptionHandler가 이 값들을 읽어 실패 응답을 만듭니다.
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/demo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/demo/domain/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.example.demo.domain.member.repository;
 
 import com.example.demo.domain.member.entity.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
@@ -9,4 +10,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * <p>JpaRepository를 상속하면 기본 CRUD 메서드가 자동으로 제공됩니다.</p>
  */
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/example/demo/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/demo/domain/member/service/MemberService.java
@@ -22,6 +22,7 @@ import com.example.demo.domain.mission.repository.MemberMissionRepository;
 import com.example.demo.domain.review.repository.ReviewRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,6 +36,9 @@ public class MemberService {
 
     // 회원 엔티티를 저장하거나 조회하는 JPA Repository입니다.
     private final MemberRepository memberRepository;
+
+    // 회원가입 시 평문 비밀번호를 BCrypt 해시로 변환합니다.
+    private final PasswordEncoder passwordEncoder;
 
     // 회원과 음식 카테고리의 다대다 관계를 연결 테이블 엔티티로 저장합니다.
     private final MemberFoodPreferenceRepository memberFoodPreferenceRepository;
@@ -56,10 +60,14 @@ public class MemberService {
      */
     @Transactional
     public MemberSignUpResponse signUp(MemberSignUpRequest request) {
+        if (memberRepository.existsByEmail(request.email())) {
+            throw new MemberException(MemberErrorCode.MEMBER_EMAIL_DUPLICATED);
+        }
+
         // 요청 DTO의 값을 사용해 아직 영속화되지 않은 회원 엔티티를 만듭니다.
         Member member = Member.create(
                 request.email(),
-                request.password(),
+                passwordEncoder.encode(request.password()),
                 request.nickname(),
                 request.gender(),
                 request.birthDate(),

--- a/src/main/java/com/example/demo/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/example/demo/global/apiPayload/code/GeneralErrorCode.java
@@ -15,7 +15,8 @@ import org.springframework.http.HttpStatus;
 public enum GeneralErrorCode implements BaseErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 내부 오류가 발생했습니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다.");
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "접근 권한이 없습니다.");
 
     // HTTP 상태, 서비스 에러 코드, 응답 메시지를 한 세트로 관리합니다.
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/demo/global/auth/CustomUserDetailsService.java
+++ b/src/main/java/com/example/demo/global/auth/CustomUserDetailsService.java
@@ -1,0 +1,31 @@
+package com.example.demo.global.auth;
+
+import com.example.demo.domain.member.entity.Member;
+import com.example.demo.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+/**
+ * Spring Security가 로그인 요청의 email로 회원을 찾을 때 사용하는 서비스입니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("Member not found: " + email));
+
+        return User.withUsername(member.getEmail())
+                .password(member.getPassword())
+                .roles("USER")
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/global/config/SecurityConfig.java
@@ -1,0 +1,103 @@
+package com.example.demo.global.config;
+
+import com.example.demo.global.apiPayload.ApiResponse;
+import com.example.demo.global.apiPayload.code.BaseErrorCode;
+import com.example.demo.global.apiPayload.code.GeneralErrorCode;
+import com.example.demo.global.apiPayload.code.GeneralSuccessCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    /**
+     * BCrypt는 비밀번호마다 다른 salt를 사용해 해시를 만듭니다.
+     */
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.sameOrigin()))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(
+                                "/api/v1/members/signup",
+                                "/login",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**",
+                                "/h2-console/**",
+                                "/error"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin(formLogin -> formLogin
+                        .loginProcessingUrl("/login")
+                        .usernameParameter("email")
+                        .passwordParameter("password")
+                        .successHandler((request, response, authentication) -> writeSuccess(
+                                response,
+                                OBJECT_MAPPER,
+                                Map.of("email", authentication.getName())
+                        ))
+                        .failureHandler((request, response, exception) ->
+                                writeError(response, OBJECT_MAPPER, GeneralErrorCode.UNAUTHORIZED))
+                        .permitAll()
+                )
+                .exceptionHandling(exceptionHandling -> exceptionHandling
+                        .authenticationEntryPoint((request, response, exception) ->
+                                writeError(response, OBJECT_MAPPER, GeneralErrorCode.UNAUTHORIZED))
+                        .accessDeniedHandler((request, response, exception) ->
+                                writeError(response, OBJECT_MAPPER, GeneralErrorCode.FORBIDDEN))
+                );
+
+        return http.build();
+    }
+
+    private static void writeSuccess(
+            HttpServletResponse response,
+            ObjectMapper objectMapper,
+            Map<String, String> result
+    ) throws IOException {
+        response.setStatus(GeneralSuccessCode.OK.getHttpStatus().value());
+        writeJson(response, objectMapper, ApiResponse.onSuccess(result));
+    }
+
+    private static void writeError(
+            HttpServletResponse response,
+            ObjectMapper objectMapper,
+            BaseErrorCode errorCode
+    ) throws IOException {
+        response.setStatus(errorCode.getHttpStatus().value());
+        writeJson(response, objectMapper, ApiResponse.onFailure(errorCode));
+    }
+
+    private static void writeJson(
+            HttpServletResponse response,
+            ObjectMapper objectMapper,
+            ApiResponse<?> apiResponse
+    ) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        objectMapper.writeValue(response.getWriter(), apiResponse);
+    }
+}

--- a/src/main/java/com/example/demo/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/demo/global/config/SwaggerConfig.java
@@ -1,10 +1,7 @@
 package com.example.demo.global.config;
 
-import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,25 +23,9 @@ public class SwaggerConfig {
                 .description("10기 Swagger")
                 .version("0.0.1");
 
-        // Swagger UI에서 사용할 인증 방식의 이름입니다.
-        String securityScheme = "JWT TOKEN";
-
-        // 모든 API 요청에 JWT 인증을 적용할 수 있도록 보안 요구사항을 추가합니다.
-        SecurityRequirement securityRequirement = new SecurityRequirement().addList(securityScheme);
-
-        // Authorization 헤더에 Bearer JWT 토큰을 넣는 HTTP 인증 방식을 정의합니다.
-        Components components = new Components()
-                .addSecuritySchemes(securityScheme, new SecurityScheme()
-                        .name(securityScheme)
-                        .type(SecurityScheme.Type.HTTP)
-                        .scheme("bearer")
-                        .bearerFormat("JWT"));
-
-        // OpenAPI 객체에 문서 정보, 서버 URL, 인증 설정을 합쳐서 반환합니다.
+        // OpenAPI 객체에 문서 정보와 서버 URL을 합쳐서 반환합니다.
         return new OpenAPI()
                 .info(info)
-                .addServersItem(new Server().url("/"))
-                .addSecurityItem(securityRequirement)
-                .components(components);
+                .addServersItem(new Server().url("/"));
     }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -25,7 +25,7 @@ values (
     1,
     'nickname012',
     'dlatplf@naver.com',
-    'password123',
+    '$2y$10$GfhQazQqEEww21FQKcOwrOzI9R5NGQo2b9lRIWOrCwUfgMLxGJGzG',
     'NONE',
     '2000-01-01',
     '서울 성북구 안암동',


### PR DESCRIPTION
<!--
  제목은 `[닉네임] 챕터 제목` 로 작성해 주세요.
  예시: [Angela] Chapter 1. 서버란 무엇인가(소켓&멀티 프로세스)
-->

## ✅ 워크북 체크리스트

- [x] 모든 핵심 키워드 정리를 마쳤나요?
- [x] 핵심 키워드에 대해 완벽히 이해하셨나요?
- [x] 이론 학습 이후 직접 실습을 해보는 시간을 가졌나요?
- [x] 미션을 수행하셨나요?
- [x] 미션을 기록하셨나요?
<br>

## ✅ 컨벤션 체크리스트

- [x] 디렉토리 구조 컨벤션을 잘 지켰나요?
- [x] pr 제목을 컨벤션에 맞게 작성하였나요?
- [x] pr에 해당되는 이슈를 연결하였나요?
- [x] 적절한 라벨을 설정하였나요?
- [x] 스터디원들에게 code review를 요청하기 위해 reviewer를 등록하였나요?
- [x] 닉네임/main 브랜치의 최신 상태를 반영하고 있는지 확인했나요?
<br>

## 📌 주안점
이번 PR에서는 Spring Security를 적용해 회원가입 API만 Public API로 열고, 그 외 API는 로그인 후 접근하도록 설정했습니다.

회원가입 시 비밀번호는 BCrypt로 암호화하여 저장하도록 수정했으며, seed 회원도 로그인 테스트가 가능하도록 data.sql의 비밀번호를 BCrypt 해시값으로 변경했습니다.

또한 인증 실패와 인가 실패 응답이 기존 ApiResponse 형식으로 내려가도록 exceptionHandling을 설정했습니다.
리뷰 시에는 Public/Private API 분리 방식, BCrypt 적용 위치, 인증 실패 응답 형식이 과제 요구사항에 맞는지 중점적으로 봐주시면 좋겠습니다.

Swagger/Postman 테스트 편의를 위해 CSRF는 비활성화했고, Swagger/H2 관련 경로는 접근 가능하도록 열어두었습니다.