### PR TITLE
[Hana] Chapter 8. Spring Security - Security 구조, 폼 로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:3.0.1'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/umc10th/domain/user/controller/AuthController.java
+++ b/src/main/java/com/example/umc10th/domain/user/controller/AuthController.java
@@ -3,9 +3,12 @@ package com.example.umc10th.domain.user.controller;
 import com.example.umc10th.domain.user.dto.UserReqDTO;
 import com.example.umc10th.domain.user.dto.UserResDTO;
 import com.example.umc10th.domain.user.exception.code.UserSuccessCode;
+import com.example.umc10th.domain.user.service.UserService;
 import com.example.umc10th.global.apiPayload.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -13,11 +16,53 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/auth")
 public class AuthController {
 
+    private final UserService userService;
+
+    // 로그인 페이지
+    @GetMapping(value = "/login", produces = MediaType.TEXT_HTML_VALUE)
+    public ResponseEntity<String> loginPage(@RequestParam(required = false) String error,
+                                            @RequestParam(required = false) String logout) {
+        String message = "";
+        if (error != null) message = "<p style='color:red'>이메일 또는 비밀번호가 올바르지 않습니다.</p>";
+        if (logout != null) message = "<p style='color:blue'>로그아웃 되었습니다.</p>";
+
+        String html = """
+                <!DOCTYPE html>
+                <html lang="ko">
+                <head>
+                    <meta charset="UTF-8">
+                    <title>Please sign in</title>
+                    <style>
+                        body { display:flex; justify-content:center; align-items:center; height:100vh; margin:0; background:#f5f5f5; font-family:sans-serif; }
+                        .box { background:white; padding:40px; border-radius:8px; width:360px; box-shadow:0 2px 8px rgba(0,0,0,0.1); }
+                        h2 { margin-bottom:24px; }
+                        input { width:100%%; padding:12px; margin-bottom:16px; border:1px solid #ccc; border-radius:4px; box-sizing:border-box; font-size:14px; }
+                        button { width:100%%; padding:12px; background:#1a73e8; color:white; border:none; border-radius:4px; font-size:16px; cursor:pointer; }
+                        button:hover { background:#1558b0; }
+                    </style>
+                </head>
+                <body>
+                    <div class="box">
+                        <h2>Please sign in</h2>
+                        %s
+                        <form method="post" action="/auth/login">
+                            <input type="email" name="email" placeholder="이메일" required autofocus/>
+                            <input type="password" name="password" placeholder="비밀번호" required/>
+                            <button type="submit">Sign in</button>
+                        </form>
+                    </div>
+                </body>
+                </html>
+                """.formatted(message);
+
+        return ResponseEntity.ok().contentType(MediaType.TEXT_HTML).body(html);
+    }
+
     // 회원가입
     @PostMapping("/users")
     public ApiResponse<UserResDTO.JoinRes> join(
             @Valid @RequestBody UserReqDTO.JoinReq request
     ) {
-        return ApiResponse.onSuccess(UserSuccessCode.USER_JOIN_OK, null);
+        return ApiResponse.onSuccess(UserSuccessCode.USER_JOIN_OK, userService.joinUser(request));
     }
 }

--- a/src/main/java/com/example/umc10th/domain/user/service/UserService.java
+++ b/src/main/java/com/example/umc10th/domain/user/service/UserService.java
@@ -1,7 +1,9 @@
 package com.example.umc10th.domain.user.service;
 
+import com.example.umc10th.domain.user.dto.UserReqDTO;
 import com.example.umc10th.domain.user.dto.UserResDTO;
 
 public interface UserService {
     UserResDTO.MyPageRes getMyPage(Long userId);
+    UserResDTO.JoinRes joinUser(UserReqDTO.JoinReq request);
 }

--- a/src/main/java/com/example/umc10th/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/umc10th/domain/user/service/UserServiceImpl.java
@@ -1,11 +1,14 @@
 package com.example.umc10th.domain.user.service;
 
+import com.example.umc10th.domain.user.dto.UserReqDTO;
 import com.example.umc10th.domain.user.dto.UserResDTO;
 import com.example.umc10th.domain.user.entity.User;
+import com.example.umc10th.domain.user.enums.Gender;
 import com.example.umc10th.domain.user.exception.UserException;
 import com.example.umc10th.domain.user.exception.code.UserErrorCode;
 import com.example.umc10th.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public UserResDTO.MyPageRes getMyPage(Long userId) {
@@ -26,6 +30,31 @@ public class UserServiceImpl implements UserService {
                 .email(user.getEmail())
                 .phoneNum(user.getPhoneNum())
                 .point(user.getPoint())
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public UserResDTO.JoinRes joinUser(UserReqDTO.JoinReq request) {
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new UserException(UserErrorCode.USER_EMAIL_DUPLICATE);
+        }
+
+        User user = User.builder()
+                .nickname(request.getNickname())
+                .email(request.getEmail())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .gender(Gender.valueOf(request.getGender()))
+                .birthDate(request.getBirth())
+                .address(request.getAddress())
+                .phoneNum(request.getPhone())
+                .build();
+
+        User saved = userRepository.save(user);
+
+        return UserResDTO.JoinRes.builder()
+                .userId(saved.getId())
+                .email(saved.getEmail())
                 .build();
     }
 }

--- a/src/main/java/com/example/umc10th/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/example/umc10th/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -34,6 +35,14 @@ public class GeneralExceptionAdvice {
         );
         return ResponseEntity.status(GeneralErrorCode.BAD_REQUEST.getStatus())
                 .body(ApiResponse.onFailure(GeneralErrorCode.BAD_REQUEST, errors));
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleNoResourceFoundException(
+            NoResourceFoundException e
+    ) {
+        return ResponseEntity.status(GeneralErrorCode.NOT_FOUND.getStatus())
+                .body(ApiResponse.onFailure(GeneralErrorCode.NOT_FOUND));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/example/umc10th/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/umc10th/global/config/SecurityConfig.java
@@ -1,0 +1,64 @@
+package com.example.umc10th.global.config;
+
+import com.example.umc10th.global.security.CustomAccessDeniedHandler;
+import com.example.umc10th.global.security.CustomAuthenticationEntryPoint;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+
+    private final String[] allowUris = {
+            // Swagger 허용
+            "/swagger-ui/**",
+            "/swagger-resources/**",
+            "/v3/api-docs/**",
+
+            // 로그인
+            "/auth/**"
+    };
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(requests -> requests
+                        .requestMatchers(allowUris).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin(form -> form
+                        .loginPage("/auth/login")
+                        .loginProcessingUrl("/auth/login")
+                        .usernameParameter("email")
+                        .defaultSuccessUrl("/swagger-ui/index.html", true)
+                        .permitAll()
+                )
+                .logout(logout -> logout
+                        .logoutUrl("/logout")
+                        .permitAll()
+                )
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler)
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/umc10th/global/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/umc10th/global/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,31 @@
+package com.example.umc10th.global.security;
+
+import com.example.umc10th.global.apiPayload.ApiResponse;
+import com.example.umc10th.global.apiPayload.code.GeneralErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        ApiResponse<Void> body = ApiResponse.onFailure(GeneralErrorCode.FORBIDDEN);
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/src/main/java/com/example/umc10th/global/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/umc10th/global/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,31 @@
+package com.example.umc10th.global.security;
+
+import com.example.umc10th.global.apiPayload.ApiResponse;
+import com.example.umc10th.global.apiPayload.code.GeneralErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        ApiResponse<Void> body = ApiResponse.onFailure(GeneralErrorCode.UNAUTHORIZED);
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/src/main/java/com/example/umc10th/global/security/CustomUserDetails.java
+++ b/src/main/java/com/example/umc10th/global/security/CustomUserDetails.java
@@ -1,0 +1,34 @@
+package com.example.umc10th.global.security;
+
+import com.example.umc10th.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    public User getUser() {
+        return user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+}

--- a/src/main/java/com/example/umc10th/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/example/umc10th/global/security/CustomUserDetailsService.java
@@ -1,0 +1,23 @@
+package com.example.umc10th.global.security;
+
+import com.example.umc10th.domain.user.entity.User;
+import com.example.umc10th.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
+        return new CustomUserDetails(user);
+    }
+}


### PR DESCRIPTION
## ✅ 워크북 체크리스트

- [x] 모든 핵심 키워드 정리를 마쳤나요?
- [x] 핵심 키워드에 대해 완벽히 이해하셨나요?
- [x] 이론 학습 이후 직접 실습을 해보는 시간을 가졌나요?
- [x] 미션을 수행하셨나요?
- [x] 미션을 기록하셨나요?
<br>

## ✅ 컨벤션 체크리스트

- [x] 디렉토리 구조 컨벤션을 잘 지켰나요?
- [x] pr 제목을 컨벤션에 맞게 작성하였나요?
- [x] pr에 해당되는 이슈를 연결하였나요?
- [x] 적절한 라벨을 설정하였나요?
- [x] 스터디원들에게 code review를 요청하기 위해 reviewer를 등록하였나요?
- [x] 닉네임/main 브랜치의 최신 상태를 반영하고 있는지 확인했나요?
<br>

## 📌 주안점
Spring Security를 적용하고 회원가입 API를 구현했습니다.
- `CustomUserDetails` / `CustomUserDetailsService` 구현
  - 로그인 식별자를 기본값 `username` 대신 `email`로 사용
- 비밀번호는 `BCryptPasswordEncoder`로 암호화하여 저장
- 회원가입 API(`POST /auth/users`)는 Public, 그 외 API는 Private으로 설정
- 인증 실패(401), 인가 실패(403) 시 `ApiResponse` 형식으로 응답 통일